### PR TITLE
fix: LessThen -> LessThan, to match CCK4 preview 25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.0.0-beta.13
+
+- fix: LessThen -> LessThan, to match CCK_4.0.0-Preview.25 and later
+
 # 3.0.0-beta.12
 
 - fix: docs

--- a/Editor/VRC3CVRCore.cs
+++ b/Editor/VRC3CVRCore.cs
@@ -1734,7 +1734,7 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
                                 });
                                 cvrDriver.EnterTasks.Add(new AnimatorDriverTask
                                 {
-                                    op = AnimatorDriverTask.Operator.LessThen,
+                                    op = AnimatorDriverTask.Operator.LessThan,
                                     targetName = vrcParameter.name,
                                     targetType = TypeOf(vrcParameter.name),
                                     aType = AnimatorDriverTask.SourceType.Parameter,


### PR DESCRIPTION
i was encountering this locally and decided i'd fix it myself rather than wait. i hope me creating a release commit and tag isn't too disruptive, as i wanted the CI to trigger on my fork :p