### PR TITLE
Fix transitions breaking when a parameter is not the type vrc3cvr assumed

### DIFF
--- a/Editor/VRC3CVRConditionTypes.cs
+++ b/Editor/VRC3CVRConditionTypes.cs
@@ -12,6 +12,11 @@ using UnityEngine;
 // ChilloutVR itself does not care: CVRAnimatorManager reads Animator.parameters for the real type
 // and dispatches to SetFloat/SetInteger/SetBool accordingly, so a Float-declared IsLocal still
 // receives its value. Only the conditions need rewriting.
+//
+// The rewrite has to happen at the moment each condition is written, not in a corrective pass
+// afterwards: Unity's own AnimatorController logs "uses parameter 'X' which is not compatible
+// with condition type" the instant an incompatible condition is live on it, so fixing the result
+// later would still leave that Console error standing.
 public static class VRC3CVRConditionTypes
 {
     // Rewrites the condition so it means the same thing against a parameter of the given type.

--- a/Editor/VRC3CVRConditionTypes.cs
+++ b/Editor/VRC3CVRConditionTypes.cs
@@ -1,0 +1,104 @@
+#if VRC_SDK_VRCSDK3 && CVR_CCK_EXISTS
+using UnityEditor.Animations;
+using UnityEngine;
+
+// Unity refuses a transition whose condition mode does not match its parameter's type, and says so
+// as "uses parameter 'X' which is not compatible with condition type" while leaving the layer dead.
+// That happens whenever the avatar declared a parameter as a different type than the condition
+// expects -- most often a Bool that had to be declared Float because a blend tree's blend parameter
+// can only be a Float. CopyParametersTo keeps the first declaration it sees, so that type reaches
+// the converted controller and every condition written against the other type breaks.
+//
+// ChilloutVR itself does not care: CVRAnimatorManager reads Animator.parameters for the real type
+// and dispatches to SetFloat/SetInteger/SetBool accordingly, so a Float-declared IsLocal still
+// receives its value. Only the conditions need rewriting.
+public static class VRC3CVRConditionTypes
+{
+    // Rewrites the condition so it means the same thing against a parameter of the given type.
+    // Returns false when no equivalent exists, in which case the caller should drop the condition
+    // and warn -- keeping it would break the whole layer, not just that transition.
+    public static bool TryAdapt(
+        AnimatorCondition condition,
+        AnimatorControllerParameterType parameterType,
+        out AnimatorCondition adapted)
+    {
+        adapted = condition;
+
+        switch (parameterType)
+        {
+            case AnimatorControllerParameterType.Bool:
+                return TryAdaptToBool(condition, ref adapted);
+            case AnimatorControllerParameterType.Float:
+                return TryAdaptToNumber(condition, isInt: false, ref adapted);
+            case AnimatorControllerParameterType.Int:
+                return TryAdaptToNumber(condition, isInt: true, ref adapted);
+            case AnimatorControllerParameterType.Trigger:
+                // A Trigger can only be tested for having fired; "has not fired" is not expressible.
+                return condition.mode == AnimatorConditionMode.If;
+            default:
+                return false;
+        }
+    }
+
+    static bool TryAdaptToBool(AnimatorCondition condition, ref AnimatorCondition adapted)
+    {
+        switch (condition.mode)
+        {
+            case AnimatorConditionMode.If:
+            case AnimatorConditionMode.IfNot:
+                return true;
+            case AnimatorConditionMode.Greater:
+                // "> t" is true only for the 1 side as long as the threshold sits below it.
+                if (condition.threshold >= 1f) return false;
+                adapted.mode = AnimatorConditionMode.If;
+                adapted.threshold = 0f;
+                return true;
+            case AnimatorConditionMode.Less:
+                if (condition.threshold <= 0f) return false;
+                adapted.mode = AnimatorConditionMode.IfNot;
+                adapted.threshold = 0f;
+                return true;
+            case AnimatorConditionMode.Equals:
+                if (Mathf.Approximately(condition.threshold, 1f)) adapted.mode = AnimatorConditionMode.If;
+                else if (Mathf.Approximately(condition.threshold, 0f)) adapted.mode = AnimatorConditionMode.IfNot;
+                else return false;
+                adapted.threshold = 0f;
+                return true;
+            case AnimatorConditionMode.NotEqual:
+                if (Mathf.Approximately(condition.threshold, 1f)) adapted.mode = AnimatorConditionMode.IfNot;
+                else if (Mathf.Approximately(condition.threshold, 0f)) adapted.mode = AnimatorConditionMode.If;
+                else return false;
+                adapted.threshold = 0f;
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    static bool TryAdaptToNumber(AnimatorCondition condition, bool isInt, ref AnimatorCondition adapted)
+    {
+        switch (condition.mode)
+        {
+            case AnimatorConditionMode.Greater:
+            case AnimatorConditionMode.Less:
+                return true;
+            case AnimatorConditionMode.Equals:
+            case AnimatorConditionMode.NotEqual:
+                // Only Int supports exact comparison; on a Float there is no single equivalent
+                // condition (it would take two, and callers cannot add conditions here).
+                return isInt;
+            case AnimatorConditionMode.If:
+                // "the bool is true" becomes "the number is on the 1 side".
+                adapted.mode = AnimatorConditionMode.Greater;
+                adapted.threshold = isInt ? 0f : 0.5f;
+                return true;
+            case AnimatorConditionMode.IfNot:
+                adapted.mode = AnimatorConditionMode.Less;
+                adapted.threshold = isInt ? 1f : 0.5f;
+                return true;
+            default:
+                return false;
+        }
+    }
+}
+#endif

--- a/Editor/VRC3CVRConditionTypes.cs.meta
+++ b/Editor/VRC3CVRConditionTypes.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1ade3de198a34e889dde16c3c4455bf6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Editor/VRC3CVRCore.cs
+++ b/Editor/VRC3CVRCore.cs
@@ -4178,7 +4178,19 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
         {
             return;
         }
-        if (!chilloutAnimatorController.parameters.Any(p => p.name == "IsLocal"))
+        // The avatar may already declare IsLocal itself, and not necessarily as a Bool: a blend
+        // tree's blend parameter has to be a Float, so an avatar that drives anything off IsLocal
+        // through a blend tree declares it Float. CopyParametersTo keeps the first declaration it
+        // sees, so that type reaches here. Match the condition mode to whatever is actually there
+        // instead of assuming Bool -- assuming it produces
+        // "uses parameter 'IsLocal' which is not compatible with condition type" and a dead layer.
+        var existingIsLocal = chilloutAnimatorController.parameters.FirstOrDefault(p => p.name == "IsLocal");
+        AnimatorConditionMode localMode;
+        AnimatorConditionMode remoteMode;
+        float localThreshold;
+        float remoteThreshold;
+
+        if (existingIsLocal == null)
         {
             var parameters = chilloutAnimatorController.parameters;
             ArrayUtility.Add(ref parameters, new AnimatorControllerParameter
@@ -4188,6 +4200,50 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
                 defaultBool = false,
             });
             chilloutAnimatorController.parameters = parameters;
+            localMode = AnimatorConditionMode.If;
+            remoteMode = AnimatorConditionMode.IfNot;
+            localThreshold = 1f;
+            remoteThreshold = 1f;
+        }
+        else
+        {
+            switch (existingIsLocal.type)
+            {
+                case AnimatorControllerParameterType.Bool:
+                    localMode = AnimatorConditionMode.If;
+                    remoteMode = AnimatorConditionMode.IfNot;
+                    localThreshold = 1f;
+                    remoteThreshold = 1f;
+                    break;
+                case AnimatorControllerParameterType.Float:
+                    localMode = AnimatorConditionMode.Greater;
+                    remoteMode = AnimatorConditionMode.Less;
+                    localThreshold = 0.5f;
+                    remoteThreshold = 0.5f;
+                    break;
+                case AnimatorControllerParameterType.Int:
+                    localMode = AnimatorConditionMode.Greater;
+                    remoteMode = AnimatorConditionMode.Less;
+                    localThreshold = 0f;
+                    remoteThreshold = 1f;
+                    break;
+                default:
+                    // A Trigger cannot express "not fired", so there is no pair of conditions that
+                    // would work. Skip the layer rather than emit a broken one.
+                    Debug.LogWarning(
+                        "VRC3CVR: the avatar declares IsLocal as " + existingIsLocal.type
+                            + ", which cannot drive the local-only contact layer. "
+                            + "Local-only contacts will stay enabled on remote copies.");
+                    return;
+            }
+
+            if (existingIsLocal.type != AnimatorControllerParameterType.Bool)
+            {
+                Debug.LogWarning(
+                    "VRC3CVR: the avatar declares IsLocal as " + existingIsLocal.type
+                        + " rather than Bool, so the local-only contact layer compares it numerically. "
+                        + "Check that ChilloutVR actually drives IsLocal in that type on your avatar.");
+            }
         }
 
         var remoteClip = new AnimationClip { name = "VRC3CVR_DisableLocalOnlyContactsOnRemote" };
@@ -4246,9 +4302,9 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
                     {
                         new AnimatorCondition
                         {
-                            mode = AnimatorConditionMode.If,
+                            mode = localMode,
                             parameter = "IsLocal",
-                            threshold = 1f,
+                            threshold = localThreshold,
                         },
                     },
                 },
@@ -4265,9 +4321,9 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
                     {
                         new AnimatorCondition
                         {
-                            mode = AnimatorConditionMode.IfNot,
+                            mode = remoteMode,
                             parameter = "IsLocal",
-                            threshold = 1f,
+                            threshold = remoteThreshold,
                         },
                     },
                 },

--- a/Editor/VRC3CVRCore.cs
+++ b/Editor/VRC3CVRCore.cs
@@ -178,6 +178,7 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
             MakeGestureWeightFeedLayers();
             MakeVelocityMagnitudeFeedLayer();
             MakeGameStateParameterStreams();
+            AdaptTransitionConditionTypesToParameterTypes();
             InsertChilloutOverride();
 
             ConvertVrcComponents();
@@ -4170,6 +4171,117 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
         }
         Debug.Log($"Remapped constraints: {clip}");
         return newClip;
+    }
+
+    // Final pass over every layer vrc3cvr ends up with (converted-from-VRC and vrc3cvr-generated
+    // alike), rewriting each transition condition's mode to match what its parameter is actually
+    // declared as on chilloutAnimatorController. This has to run after every layer exists --
+    // ProcessTransition runs along several different code paths while layers are being built, and
+    // vrc3cvr's own generated layers (gesture weight feed, velocity magnitude, game state streams)
+    // are added afterwards -- so a single pass at the very end is the only way not to miss any of
+    // them. See VRC3CVRConditionTypes for why the mismatch happens and why adapting instead of
+    // forcing the parameter back to Bool is correct (ChilloutVR type-casts on send).
+    void AdaptTransitionConditionTypesToParameterTypes()
+    {
+        var parameterTypes = chilloutAnimatorController.parameters.ToDictionary(p => p.name, p => p.type);
+        var adaptedCount = 0;
+        var droppedCount = 0;
+
+        foreach (var layer in chilloutAnimatorController.layers)
+        {
+            AdaptConditionTypesOnStateMachine(layer.stateMachine, layer.name, parameterTypes, ref adaptedCount, ref droppedCount);
+        }
+
+        if (adaptedCount > 0 || droppedCount > 0)
+        {
+            Debug.Log($"VRC3CVR: adapted {adaptedCount} transition condition(s) to match their parameter's actual type, dropped {droppedCount} that had no equivalent.");
+        }
+    }
+
+    void AdaptConditionTypesOnStateMachine(AnimatorStateMachine stateMachine, string layerName, Dictionary<string, AnimatorControllerParameterType> parameterTypes, ref int adaptedCount, ref int droppedCount)
+    {
+        var anyStateTransitions = stateMachine.anyStateTransitions;
+        if (AdaptConditionTypesOnTransitions(anyStateTransitions, layerName, "AnyState", parameterTypes, ref adaptedCount, ref droppedCount))
+        {
+            stateMachine.anyStateTransitions = anyStateTransitions;
+        }
+
+        var entryTransitions = stateMachine.entryTransitions;
+        if (AdaptConditionTypesOnTransitions(entryTransitions, layerName, "Entry", parameterTypes, ref adaptedCount, ref droppedCount))
+        {
+            stateMachine.entryTransitions = entryTransitions;
+        }
+
+        foreach (var childState in stateMachine.states)
+        {
+            var transitions = childState.state.transitions;
+            if (AdaptConditionTypesOnTransitions(transitions, layerName, $"state '{childState.state.name}'", parameterTypes, ref adaptedCount, ref droppedCount))
+            {
+                childState.state.transitions = transitions;
+            }
+        }
+
+        foreach (var subMachine in stateMachine.stateMachines)
+        {
+            var transitions = stateMachine.GetStateMachineTransitions(subMachine.stateMachine);
+            if (AdaptConditionTypesOnTransitions(transitions, layerName, $"transition into sub-state-machine '{subMachine.stateMachine.name}'", parameterTypes, ref adaptedCount, ref droppedCount))
+            {
+                stateMachine.SetStateMachineTransitions(subMachine.stateMachine, transitions);
+            }
+        }
+
+        foreach (var childStateMachine in stateMachine.stateMachines)
+        {
+            AdaptConditionTypesOnStateMachine(childStateMachine.stateMachine, layerName, parameterTypes, ref adaptedCount, ref droppedCount);
+        }
+    }
+
+    // Returns whether any condition on any of the given transitions changed (adapted or dropped),
+    // so the caller only has to write the transitions array back when something actually moved.
+    bool AdaptConditionTypesOnTransitions<T>(T[] transitions, string layerName, string context, Dictionary<string, AnimatorControllerParameterType> parameterTypes, ref int adaptedCount, ref int droppedCount) where T : AnimatorTransitionBase
+    {
+        var changedAny = false;
+
+        foreach (var transition in transitions)
+        {
+            var conditions = transition.conditions;
+            var changed = false;
+            var kept = new List<AnimatorCondition>(conditions.Length);
+
+            foreach (var condition in conditions)
+            {
+                if (!parameterTypes.TryGetValue(condition.parameter, out var parameterType))
+                {
+                    // Not a parameter we know about on this controller -- somebody else's problem.
+                    kept.Add(condition);
+                    continue;
+                }
+
+                if (VRC3CVRConditionTypes.TryAdapt(condition, parameterType, out var adapted))
+                {
+                    if (adapted.mode != condition.mode || !Mathf.Approximately(adapted.threshold, condition.threshold))
+                    {
+                        adaptedCount++;
+                        changed = true;
+                    }
+                    kept.Add(adapted);
+                }
+                else
+                {
+                    droppedCount++;
+                    changed = true;
+                    Debug.LogWarning($"VRC3CVR: dropped a transition condition on layer '{layerName}', {context} -- parameter '{condition.parameter}' is {parameterType} and has no equivalent for condition mode {condition.mode}. The transition may now behave differently than on VRChat.");
+                }
+            }
+
+            if (changed)
+            {
+                transition.conditions = kept.ToArray();
+                changedAny = true;
+            }
+        }
+
+        return changedAny;
     }
 
     void EnsureLocalOnlyContacts()

--- a/Editor/VRC3CVRCore.cs
+++ b/Editor/VRC3CVRCore.cs
@@ -1405,13 +1405,8 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
     }
 
     // layerName/context/parameterTypes exist purely to adapt each generated condition's mode to
-    // the type its parameter actually has on chilloutAnimatorController before it is ever written
-    // onto a transition -- see VRC3CVRConditionTypes for why the mismatch happens. It has to happen
-    // here, at generation time, and nowhere else: Unity's own AnimatorController logs "uses
-    // parameter 'X' which is not compatible with condition type" the moment an incompatible
-    // condition is live on it, so a corrective pass afterwards would fix the result but leave the
-    // Console error standing. That is why ProcessStateMachine walks every kind of transition a
-    // state machine can hold rather than relying on anything downstream to catch the rest.
+    // the type its parameter actually has on chilloutAnimatorController, and to warn when that
+    // adaptation is not possible -- see VRC3CVRConditionTypes for why the mismatch happens.
     void ProcessTransition<AnimatorTranstitionType>(AnimatorTranstitionType transition, List<AnimatorTranstitionType> transitionsToAdd, List<AnimatorCondition> conditionsToAdd, string layerName, string context, Dictionary<string, AnimatorControllerParameterType> parameterTypes, bool isDuplicate = false) where AnimatorTranstitionType : AnimatorTransitionBase, new()
     {
         // Convert GestureLeft/GestureRight to ChilloutVR
@@ -1742,27 +1737,25 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
         // right before it is committed to the transition -- conditionsToAdd is mutated in place (not
         // just used to set transition.conditions here) because callers of the recursive
         // ProcessTransition calls above re-read the same list object afterwards.
-        var adaptedConditions = new List<AnimatorCondition>(conditionsToAdd.Count);
-        foreach (var conditionToAdd in conditionsToAdd)
+        for (int i = conditionsToAdd.Count - 1; i >= 0; i--)
         {
+            var conditionToAdd = conditionsToAdd[i];
             if (!parameterTypes.TryGetValue(conditionToAdd.parameter, out var parameterType))
             {
                 // Not a parameter chilloutAnimatorController knows about yet -- somebody else's problem.
-                adaptedConditions.Add(conditionToAdd);
                 continue;
             }
 
             if (VRC3CVRConditionTypes.TryAdapt(conditionToAdd, parameterType, out var adaptedCondition))
             {
-                adaptedConditions.Add(adaptedCondition);
+                conditionsToAdd[i] = adaptedCondition;
             }
             else
             {
                 Debug.LogWarning($"VRC3CVR: dropped a transition condition on layer '{layerName}', {context} -- parameter '{conditionToAdd.parameter}' is {parameterType} and has no equivalent for condition mode {conditionToAdd.mode}. The transition may now behave differently than on VRChat.");
+                conditionsToAdd.RemoveAt(i);
             }
         }
-        conditionsToAdd.Clear();
-        conditionsToAdd.AddRange(adaptedConditions);
 
         transition.conditions = conditionsToAdd.ToArray();
     }
@@ -2256,12 +2249,10 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
         stateMachine.entryTransitions = ProcessTransitions(stateMachine.entryTransitions, layerName, "Entry");
 
         // A sub-state-machine's own outgoing transitions (to a sibling state, to another
-        // sub-state-machine, or to Exit) are not stored on that sub-state-machine: Unity keeps them
-        // on its *parent*, reachable only through GetStateMachineTransitions/SetStateMachineTransitions.
-        // The recursion below descends into the child, which never sees them, so without this loop
-        // they were the one kind of transition whose conditions no code path converted -- neither the
-        // gesture rewrite nor the condition-type adaptation. AdjustParameterNamesOnStateMachine
-        // already walks all four kinds; this makes the set match.
+        // sub-state-machine, or to Exit) are stored on its *parent*, not on the sub-state-machine
+        // itself -- reachable only through GetStateMachineTransitions/SetStateMachineTransitions.
+        // The recursion below descends into the child, which never sees them, so they have to be
+        // picked up here.
         foreach (ChildAnimatorStateMachine childStateMachine in stateMachine.stateMachines)
         {
             var subMachine = childStateMachine.stateMachine;
@@ -4263,10 +4254,8 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
         // instead of assuming Bool -- assuming it produces
         // "uses parameter 'IsLocal' which is not compatible with condition type" and a dead layer.
         var existingIsLocal = chilloutAnimatorController.parameters.FirstOrDefault(p => p.name == "IsLocal");
-        AnimatorConditionMode localMode;
-        AnimatorConditionMode remoteMode;
-        float localThreshold;
-        float remoteThreshold;
+        AnimatorCondition localCondition;
+        AnimatorCondition remoteCondition;
 
         if (existingIsLocal == null)
         {
@@ -4278,41 +4267,23 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
                 defaultBool = false,
             });
             chilloutAnimatorController.parameters = parameters;
-            localMode = AnimatorConditionMode.If;
-            remoteMode = AnimatorConditionMode.IfNot;
-            localThreshold = 1f;
-            remoteThreshold = 1f;
+            localCondition = new AnimatorCondition { mode = AnimatorConditionMode.If, parameter = "IsLocal", threshold = 1f };
+            remoteCondition = new AnimatorCondition { mode = AnimatorConditionMode.IfNot, parameter = "IsLocal", threshold = 1f };
         }
         else
         {
-            switch (existingIsLocal.type)
+            var rawLocal = new AnimatorCondition { mode = AnimatorConditionMode.If, parameter = "IsLocal", threshold = 1f };
+            var rawRemote = new AnimatorCondition { mode = AnimatorConditionMode.IfNot, parameter = "IsLocal", threshold = 1f };
+            if (!VRC3CVRConditionTypes.TryAdapt(rawLocal, existingIsLocal.type, out localCondition)
+                || !VRC3CVRConditionTypes.TryAdapt(rawRemote, existingIsLocal.type, out remoteCondition))
             {
-                case AnimatorControllerParameterType.Bool:
-                    localMode = AnimatorConditionMode.If;
-                    remoteMode = AnimatorConditionMode.IfNot;
-                    localThreshold = 1f;
-                    remoteThreshold = 1f;
-                    break;
-                case AnimatorControllerParameterType.Float:
-                    localMode = AnimatorConditionMode.Greater;
-                    remoteMode = AnimatorConditionMode.Less;
-                    localThreshold = 0.5f;
-                    remoteThreshold = 0.5f;
-                    break;
-                case AnimatorControllerParameterType.Int:
-                    localMode = AnimatorConditionMode.Greater;
-                    remoteMode = AnimatorConditionMode.Less;
-                    localThreshold = 0f;
-                    remoteThreshold = 1f;
-                    break;
-                default:
-                    // A Trigger cannot express "not fired", so there is no pair of conditions that
-                    // would work. Skip the layer rather than emit a broken one.
-                    Debug.LogWarning(
-                        "VRC3CVR: the avatar declares IsLocal as " + existingIsLocal.type
-                            + ", which cannot drive the local-only contact layer. "
-                            + "Local-only contacts will stay enabled on remote copies.");
-                    return;
+                // A Trigger cannot express "not fired", so there is no pair of conditions that
+                // would work. Skip the layer rather than emit a broken one.
+                Debug.LogWarning(
+                    "VRC3CVR: the avatar declares IsLocal as " + existingIsLocal.type
+                        + ", which cannot drive the local-only contact layer. "
+                        + "Local-only contacts will stay enabled on remote copies.");
+                return;
             }
 
             if (existingIsLocal.type != AnimatorControllerParameterType.Bool)
@@ -4376,15 +4347,7 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
                     duration = 0f,
                     offset = 0f,
                     destinationState = localState,
-                    conditions = new AnimatorCondition[]
-                    {
-                        new AnimatorCondition
-                        {
-                            mode = localMode,
-                            parameter = "IsLocal",
-                            threshold = localThreshold,
-                        },
-                    },
+                    conditions = new AnimatorCondition[] { localCondition },
                 },
                 new AnimatorStateTransition
                 {
@@ -4395,15 +4358,7 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
                     duration = 0f,
                     offset = 0f,
                     destinationState = remoteState,
-                    conditions = new AnimatorCondition[]
-                    {
-                        new AnimatorCondition
-                        {
-                            mode = remoteMode,
-                            parameter = "IsLocal",
-                            threshold = remoteThreshold,
-                        },
-                    },
+                    conditions = new AnimatorCondition[] { remoteCondition },
                 },
             },
         };

--- a/Editor/VRC3CVRCore.cs
+++ b/Editor/VRC3CVRCore.cs
@@ -2521,14 +2521,9 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
 
         var newAnimatorController = new CopyAnimatorController(originalAnimatorController).CopyController();
 
-        // Register this animator's own parameters on chilloutAnimatorController before processing
-        // its transitions below. Without this, a parameter this very animator is the first to
-        // declare (e.g. IsLocal used only on this one animator) would not show up in
-        // chilloutAnimatorController.parameters until CopyControllerTo merges this whole animator in
-        // further down -- by which point its still-unadapted conditions would already be attached to
-        // chilloutAnimatorController, which is exactly the transient "not compatible with condition
-        // type" Console error this whole change exists to avoid. CopyParametersTo is idempotent, so
-        // the later call inside CopyControllerTo is a no-op for every name already added here.
+        // Register this animator's own parameters before processing its transitions below;
+        // otherwise a parameter only this animator declares (e.g. IsLocal) is unknown until
+        // CopyControllerTo merges it in later, and its conditions go out unadapted. Idempotent.
         new CopyAnimatorController(newAnimatorController).CopyParametersTo(chilloutAnimatorController);
 
         var controllerLayers = newAnimatorController.layers;

--- a/Editor/VRC3CVRCore.cs
+++ b/Editor/VRC3CVRCore.cs
@@ -39,13 +39,6 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
     GameObject chilloutAvatarGameObject;
     public GameObject chilloutAvatar => chilloutAvatarGameObject;
 
-    // Set by AdaptTransitionConditionTypesToParameterTypes, the end-of-conversion safety net.
-    // Exposed (via reflection in tests) so a test can assert this stays 0 -- i.e. that
-    // ProcessTransition already adapted every condition at generation time and this pass had
-    // nothing left to fix.
-    int lastAdaptedConditionCount;
-    int lastDroppedConditionCount;
-
     public static VRC3CVRCore FromConfig(VRC3CVRConvertConfig config)
     {
         var core = new VRC3CVRCore();
@@ -185,7 +178,6 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
             MakeGestureWeightFeedLayers();
             MakeVelocityMagnitudeFeedLayer();
             MakeGameStateParameterStreams();
-            AdaptTransitionConditionTypesToParameterTypes();
             InsertChilloutOverride();
 
             ConvertVrcComponents();
@@ -1414,10 +1406,12 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
 
     // layerName/context/parameterTypes exist purely to adapt each generated condition's mode to
     // the type its parameter actually has on chilloutAnimatorController before it is ever written
-    // onto a transition -- see VRC3CVRConditionTypes for why the mismatch happens. Doing this here,
-    // at generation time, means Unity's own AnimatorController never sees an incompatible condition
-    // even transiently, unlike AdaptTransitionConditionTypesToParameterTypes's end-of-conversion
-    // pass which necessarily runs after the mismatch has already been live on the controller once.
+    // onto a transition -- see VRC3CVRConditionTypes for why the mismatch happens. It has to happen
+    // here, at generation time, and nowhere else: Unity's own AnimatorController logs "uses
+    // parameter 'X' which is not compatible with condition type" the moment an incompatible
+    // condition is live on it, so a corrective pass afterwards would fix the result but leave the
+    // Console error standing. That is why ProcessStateMachine walks every kind of transition a
+    // state machine can hold rather than relying on anything downstream to catch the rest.
     void ProcessTransition<AnimatorTranstitionType>(AnimatorTranstitionType transition, List<AnimatorTranstitionType> transitionsToAdd, List<AnimatorCondition> conditionsToAdd, string layerName, string context, Dictionary<string, AnimatorControllerParameterType> parameterTypes, bool isDuplicate = false) where AnimatorTranstitionType : AnimatorTransitionBase, new()
     {
         // Convert GestureLeft/GestureRight to ChilloutVR
@@ -2266,8 +2260,8 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
         // on its *parent*, reachable only through GetStateMachineTransitions/SetStateMachineTransitions.
         // The recursion below descends into the child, which never sees them, so without this loop
         // they were the one kind of transition whose conditions no code path converted -- neither the
-        // gesture rewrite nor the condition-type adaptation. AdjustParameterNamesOnStateMachine and
-        // AdaptConditionTypesOnStateMachine both already walk them; this makes the set match.
+        // gesture rewrite nor the condition-type adaptation. AdjustParameterNamesOnStateMachine
+        // already walks all four kinds; this makes the set match.
         foreach (ChildAnimatorStateMachine childStateMachine in stateMachine.stateMachines)
         {
             var subMachine = childStateMachine.stateMachine;
@@ -4254,120 +4248,6 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
         }
         Debug.Log($"Remapped constraints: {clip}");
         return newClip;
-    }
-
-    // Final pass over every layer vrc3cvr ends up with (converted-from-VRC and vrc3cvr-generated
-    // alike), rewriting each transition condition's mode to match what its parameter is actually
-    // declared as on chilloutAnimatorController. This has to run after every layer exists --
-    // ProcessTransition runs along several different code paths while layers are being built, and
-    // vrc3cvr's own generated layers (gesture weight feed, velocity magnitude, game state streams)
-    // are added afterwards -- so a single pass at the very end is the only way not to miss any of
-    // them. See VRC3CVRConditionTypes for why the mismatch happens and why adapting instead of
-    // forcing the parameter back to Bool is correct (ChilloutVR type-casts on send).
-    void AdaptTransitionConditionTypesToParameterTypes()
-    {
-        var parameterTypes = chilloutAnimatorController.parameters.ToDictionary(p => p.name, p => p.type);
-        var adaptedCount = 0;
-        var droppedCount = 0;
-
-        foreach (var layer in chilloutAnimatorController.layers)
-        {
-            AdaptConditionTypesOnStateMachine(layer.stateMachine, layer.name, parameterTypes, ref adaptedCount, ref droppedCount);
-        }
-
-        lastAdaptedConditionCount = adaptedCount;
-        lastDroppedConditionCount = droppedCount;
-
-        if (adaptedCount > 0 || droppedCount > 0)
-        {
-            Debug.Log($"VRC3CVR: adapted {adaptedCount} transition condition(s) to match their parameter's actual type, dropped {droppedCount} that had no equivalent.");
-        }
-    }
-
-    void AdaptConditionTypesOnStateMachine(AnimatorStateMachine stateMachine, string layerName, Dictionary<string, AnimatorControllerParameterType> parameterTypes, ref int adaptedCount, ref int droppedCount)
-    {
-        var anyStateTransitions = stateMachine.anyStateTransitions;
-        if (AdaptConditionTypesOnTransitions(anyStateTransitions, layerName, "AnyState", parameterTypes, ref adaptedCount, ref droppedCount))
-        {
-            stateMachine.anyStateTransitions = anyStateTransitions;
-        }
-
-        var entryTransitions = stateMachine.entryTransitions;
-        if (AdaptConditionTypesOnTransitions(entryTransitions, layerName, "Entry", parameterTypes, ref adaptedCount, ref droppedCount))
-        {
-            stateMachine.entryTransitions = entryTransitions;
-        }
-
-        foreach (var childState in stateMachine.states)
-        {
-            var transitions = childState.state.transitions;
-            if (AdaptConditionTypesOnTransitions(transitions, layerName, $"state '{childState.state.name}'", parameterTypes, ref adaptedCount, ref droppedCount))
-            {
-                childState.state.transitions = transitions;
-            }
-        }
-
-        foreach (var subMachine in stateMachine.stateMachines)
-        {
-            var transitions = stateMachine.GetStateMachineTransitions(subMachine.stateMachine);
-            if (AdaptConditionTypesOnTransitions(transitions, layerName, $"transition into sub-state-machine '{subMachine.stateMachine.name}'", parameterTypes, ref adaptedCount, ref droppedCount))
-            {
-                stateMachine.SetStateMachineTransitions(subMachine.stateMachine, transitions);
-            }
-        }
-
-        foreach (var childStateMachine in stateMachine.stateMachines)
-        {
-            AdaptConditionTypesOnStateMachine(childStateMachine.stateMachine, layerName, parameterTypes, ref adaptedCount, ref droppedCount);
-        }
-    }
-
-    // Returns whether any condition on any of the given transitions changed (adapted or dropped),
-    // so the caller only has to write the transitions array back when something actually moved.
-    bool AdaptConditionTypesOnTransitions<T>(T[] transitions, string layerName, string context, Dictionary<string, AnimatorControllerParameterType> parameterTypes, ref int adaptedCount, ref int droppedCount) where T : AnimatorTransitionBase
-    {
-        var changedAny = false;
-
-        foreach (var transition in transitions)
-        {
-            var conditions = transition.conditions;
-            var changed = false;
-            var kept = new List<AnimatorCondition>(conditions.Length);
-
-            foreach (var condition in conditions)
-            {
-                if (!parameterTypes.TryGetValue(condition.parameter, out var parameterType))
-                {
-                    // Not a parameter we know about on this controller -- somebody else's problem.
-                    kept.Add(condition);
-                    continue;
-                }
-
-                if (VRC3CVRConditionTypes.TryAdapt(condition, parameterType, out var adapted))
-                {
-                    if (adapted.mode != condition.mode || !Mathf.Approximately(adapted.threshold, condition.threshold))
-                    {
-                        adaptedCount++;
-                        changed = true;
-                    }
-                    kept.Add(adapted);
-                }
-                else
-                {
-                    droppedCount++;
-                    changed = true;
-                    Debug.LogWarning($"VRC3CVR: dropped a transition condition on layer '{layerName}', {context} -- parameter '{condition.parameter}' is {parameterType} and has no equivalent for condition mode {condition.mode}. The transition may now behave differently than on VRChat.");
-                }
-            }
-
-            if (changed)
-            {
-                transition.conditions = kept.ToArray();
-                changedAny = true;
-            }
-        }
-
-        return changedAny;
     }
 
     void EnsureLocalOnlyContacts()

--- a/Editor/VRC3CVRCore.cs
+++ b/Editor/VRC3CVRCore.cs
@@ -39,6 +39,13 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
     GameObject chilloutAvatarGameObject;
     public GameObject chilloutAvatar => chilloutAvatarGameObject;
 
+    // Set by AdaptTransitionConditionTypesToParameterTypes, the end-of-conversion safety net.
+    // Exposed (via reflection in tests) so a test can assert this stays 0 -- i.e. that
+    // ProcessTransition already adapted every condition at generation time and this pass had
+    // nothing left to fix.
+    int lastAdaptedConditionCount;
+    int lastDroppedConditionCount;
+
     public static VRC3CVRCore FromConfig(VRC3CVRConvertConfig config)
     {
         var core = new VRC3CVRCore();
@@ -1362,18 +1369,29 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
         return finalParams.ToArray();
     }
 
-    AnimatorTransition[] ProcessTransitions(AnimatorTransition[] transitions)
+    AnimatorTransition[] ProcessTransitions(AnimatorTransition[] transitions, string layerName, string context)
     {
-        return ProcessTransitions<AnimatorTransition>(transitions);
+        return ProcessTransitions<AnimatorTransition>(transitions, layerName, context);
     }
 
-    AnimatorStateTransition[] ProcessTransitions(AnimatorStateTransition[] transitions)
+    AnimatorStateTransition[] ProcessTransitions(AnimatorStateTransition[] transitions, string layerName, string context)
     {
-        return ProcessTransitions<AnimatorStateTransition>(transitions);
+        return ProcessTransitions<AnimatorStateTransition>(transitions, layerName, context);
     }
 
-    AnimatorTranstitionType[] ProcessTransitions<AnimatorTranstitionType>(AnimatorTranstitionType[] transitions) where AnimatorTranstitionType : AnimatorTransitionBase, new()
+    AnimatorTranstitionType[] ProcessTransitions<AnimatorTranstitionType>(AnimatorTranstitionType[] transitions, string layerName, string context) where AnimatorTranstitionType : AnimatorTransitionBase, new()
     {
+        // Built once per batch rather than once per condition -- chilloutAnimatorController.parameters
+        // returns a fresh copy array on every access. By now it already holds the merged (first-wins)
+        // type for every parameter this animator could reference, including ones this very animator
+        // introduces (see the early CopyParametersTo call in MergeVrcAnimatorIntoChilloutAnimator).
+        // chilloutAnimatorController itself is only null in tests that exercise this method in
+        // isolation (see VRC3CVRGestureConversionTests); nothing is known about any parameter's type
+        // there, so every condition simply passes through TryAdapt's "not found" branch unchanged.
+        var parameterTypes = chilloutAnimatorController != null
+            ? chilloutAnimatorController.parameters.ToDictionary(p => p.name, p => p.type)
+            : new Dictionary<string, AnimatorControllerParameterType>();
+
         List<AnimatorTranstitionType> transitionsToAdd = new List<AnimatorTranstitionType>();
 
         for (int t = 0; t < transitions.Length; t++)
@@ -1383,7 +1401,7 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
 
             // Debug.Log(transitions[t].conditions.Length + " conditions");
 
-            ProcessTransition(transition, transitionsToAdd, conditionsToAdd);
+            ProcessTransition(transition, transitionsToAdd, conditionsToAdd, layerName, context, parameterTypes);
         }
 
         AnimatorTranstitionType[] newTransitions = new AnimatorTranstitionType[transitions.Length + transitionsToAdd.Count];
@@ -1394,7 +1412,13 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
         return newTransitions;
     }
 
-    void ProcessTransition<AnimatorTranstitionType>(AnimatorTranstitionType transition, List<AnimatorTranstitionType> transitionsToAdd, List<AnimatorCondition> conditionsToAdd, bool isDuplicate = false) where AnimatorTranstitionType : AnimatorTransitionBase, new()
+    // layerName/context/parameterTypes exist purely to adapt each generated condition's mode to
+    // the type its parameter actually has on chilloutAnimatorController before it is ever written
+    // onto a transition -- see VRC3CVRConditionTypes for why the mismatch happens. Doing this here,
+    // at generation time, means Unity's own AnimatorController never sees an incompatible condition
+    // even transiently, unlike AdaptTransitionConditionTypesToParameterTypes's end-of-conversion
+    // pass which necessarily runs after the mismatch has already been live on the controller once.
+    void ProcessTransition<AnimatorTranstitionType>(AnimatorTranstitionType transition, List<AnimatorTranstitionType> transitionsToAdd, List<AnimatorCondition> conditionsToAdd, string layerName, string context, Dictionary<string, AnimatorControllerParameterType> parameterTypes, bool isDuplicate = false) where AnimatorTranstitionType : AnimatorTransitionBase, new()
     {
         // Convert GestureLeft/GestureRight to ChilloutVR
         for (int c = 0; c < transition.conditions.Length; c++)
@@ -1436,7 +1460,7 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
                         List<AnimatorTranstitionType> transitionsToAdd2 = new List<AnimatorTranstitionType>();
                         List<AnimatorCondition> conditionsToAdd2 = new List<AnimatorCondition>();
 
-                        ProcessTransition(newTransition, transitionsToAdd2, conditionsToAdd2, isDuplicate);
+                        ProcessTransition(newTransition, transitionsToAdd2, conditionsToAdd2, layerName, context, parameterTypes, isDuplicate);
                         newTransition.conditions = conditionsToAdd2.ToArray();
 
                         transitionsToAdd.Add(newTransition);
@@ -1591,7 +1615,7 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
                         List<AnimatorTranstitionType> transitionsToAdd2 = new List<AnimatorTranstitionType>();
                         List<AnimatorCondition> conditionsToAdd2 = new List<AnimatorCondition>();
 
-                        ProcessTransition(newTransition, transitionsToAdd2, conditionsToAdd2, true);
+                        ProcessTransition(newTransition, transitionsToAdd2, conditionsToAdd2, layerName, context, parameterTypes, true);
                         newTransition.conditions = conditionsToAdd2.ToArray();
 
                         transitionsToAdd.Add(newTransition);
@@ -1709,7 +1733,7 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
                             conditionsToAdd.Add(newConditionGreaterThan);
 
                             // ...or any non-Neutral non-Fist gesture, whose weight is fixed 1
-                            AddGestureWeightRunDuplicates(transition, c, parameterName, transitionsToAdd);
+                            AddGestureWeightRunDuplicates(transition, c, parameterName, transitionsToAdd, layerName, context, parameterTypes);
                         }
                     }
                 }
@@ -1719,6 +1743,32 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
                 conditionsToAdd.Add(condition);
             }
         }
+
+        // Adapt every condition to the type its parameter actually has on chilloutAnimatorController
+        // right before it is committed to the transition -- conditionsToAdd is mutated in place (not
+        // just used to set transition.conditions here) because callers of the recursive
+        // ProcessTransition calls above re-read the same list object afterwards.
+        var adaptedConditions = new List<AnimatorCondition>(conditionsToAdd.Count);
+        foreach (var conditionToAdd in conditionsToAdd)
+        {
+            if (!parameterTypes.TryGetValue(conditionToAdd.parameter, out var parameterType))
+            {
+                // Not a parameter chilloutAnimatorController knows about yet -- somebody else's problem.
+                adaptedConditions.Add(conditionToAdd);
+                continue;
+            }
+
+            if (VRC3CVRConditionTypes.TryAdapt(conditionToAdd, parameterType, out var adaptedCondition))
+            {
+                adaptedConditions.Add(adaptedCondition);
+            }
+            else
+            {
+                Debug.LogWarning($"VRC3CVR: dropped a transition condition on layer '{layerName}', {context} -- parameter '{conditionToAdd.parameter}' is {parameterType} and has no equivalent for condition mode {conditionToAdd.mode}. The transition may now behave differently than on VRChat.");
+            }
+        }
+        conditionsToAdd.Clear();
+        conditionsToAdd.AddRange(adaptedConditions);
 
         transition.conditions = conditionsToAdd.ToArray();
     }
@@ -1823,8 +1873,11 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
     // Fold mode: a standalone weight condition is also satisfied by every non-Neutral
     // non-Fist gesture (their weight is fixed 1 in VRChat). Those gestures sit at
     // -1 (open hand) and 2..6 in ChilloutVR, so add one OR transition per range.
-    void AddGestureWeightRunDuplicates<AnimatorTranstitionType>(AnimatorTranstitionType transition, int conditionIndex, string gestureParameterName, List<AnimatorTranstitionType> transitionsToAdd) where AnimatorTranstitionType : AnimatorTransitionBase, new()
+    void AddGestureWeightRunDuplicates<AnimatorTranstitionType>(AnimatorTranstitionType transition, int conditionIndex, string gestureParameterName, List<AnimatorTranstitionType> transitionsToAdd, string layerName, string context, Dictionary<string, AnimatorControllerParameterType> parameterTypes) where AnimatorTranstitionType : AnimatorTransitionBase, new()
     {
+        // GestureLeft/GestureRight are always Float in ChilloutVR (declared as such on the template
+        // AvatarAnimator.controller before any VRC layer is merged in), so these Greater/Less
+        // conditions never need TryAdapt -- they are added straight onto the already-adapted list below.
         var runConditions = new AnimatorCondition[]
         {
             new AnimatorCondition { parameter = gestureParameterName, mode = AnimatorConditionMode.Less, threshold = -0.9f },
@@ -1837,7 +1890,7 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
             List<AnimatorTranstitionType> transitionsToAdd2 = new List<AnimatorTranstitionType>();
             List<AnimatorCondition> conditionsToAdd2 = new List<AnimatorCondition>();
 
-            ProcessTransition(newTransition, transitionsToAdd2, conditionsToAdd2);
+            ProcessTransition(newTransition, transitionsToAdd2, conditionsToAdd2, layerName, context, parameterTypes);
             conditionsToAdd2.Add(runCondition);
             newTransition.conditions = conditionsToAdd2.ToArray();
 
@@ -1938,7 +1991,7 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
         return clip;
     }
 
-    void ProcessStateMachine(AnimatorStateMachine stateMachine, ref AnimatorControllerParameter[] parameters)
+    void ProcessStateMachine(AnimatorStateMachine stateMachine, string layerName, ref AnimatorControllerParameter[] parameters)
     {
         for (int s = 0; s < stateMachine.states.Length; s++)
         {
@@ -2189,7 +2242,7 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
                 }
             }
 
-            AnimatorStateTransition[] newTransitions = ProcessTransitions(state.transitions);
+            AnimatorStateTransition[] newTransitions = ProcessTransitions(state.transitions, layerName, $"state '{state.name}'");
             state.transitions = newTransitions;
         }
 
@@ -2205,8 +2258,8 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
             }
         }
 
-        stateMachine.anyStateTransitions = ProcessTransitions(stateMachine.anyStateTransitions);
-        stateMachine.entryTransitions = ProcessTransitions(stateMachine.entryTransitions);
+        stateMachine.anyStateTransitions = ProcessTransitions(stateMachine.anyStateTransitions, layerName, "AnyState");
+        stateMachine.entryTransitions = ProcessTransitions(stateMachine.entryTransitions, layerName, "Entry");
 
         if (stateMachine.stateMachines.Length > 0)
         {
@@ -2215,7 +2268,7 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
 
         foreach (ChildAnimatorStateMachine childStateMachine in stateMachine.stateMachines)
         {
-            ProcessStateMachine(childStateMachine.stateMachine, ref parameters);
+            ProcessStateMachine(childStateMachine.stateMachine, layerName, ref parameters);
         }
     }
 
@@ -2463,6 +2516,16 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
 
         var newAnimatorController = new CopyAnimatorController(originalAnimatorController).CopyController();
 
+        // Register this animator's own parameters on chilloutAnimatorController before processing
+        // its transitions below. Without this, a parameter this very animator is the first to
+        // declare (e.g. IsLocal used only on this one animator) would not show up in
+        // chilloutAnimatorController.parameters until CopyControllerTo merges this whole animator in
+        // further down -- by which point its still-unadapted conditions would already be attached to
+        // chilloutAnimatorController, which is exactly the transient "not compatible with condition
+        // type" Console error this whole change exists to avoid. CopyParametersTo is idempotent, so
+        // the later call inside CopyControllerTo is a no-op for every name already added here.
+        new CopyAnimatorController(newAnimatorController).CopyParametersTo(chilloutAnimatorController);
+
         var controllerLayers = newAnimatorController.layers;
         var layersModified = false;
         // Unity forces the first layer's runtime weight to 1 regardless of its serialized value
@@ -2482,7 +2545,7 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
                 Debug.Log("Layer \"" + layer.name + "\" with " + layer.stateMachine.states.Length + " states");
 
                 var parameters = newAnimatorController.parameters;
-                ProcessStateMachine(layer.stateMachine, ref parameters);
+                ProcessStateMachine(layer.stateMachine, layer.name, ref parameters);
                 newAnimatorController.parameters = parameters;
 
                 layer.avatarMask = GetAvatarMaskForLayerAndVRCAnimator(animatorID, i, layer.avatarMask);
@@ -4191,6 +4254,9 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
         {
             AdaptConditionTypesOnStateMachine(layer.stateMachine, layer.name, parameterTypes, ref adaptedCount, ref droppedCount);
         }
+
+        lastAdaptedConditionCount = adaptedCount;
+        lastDroppedConditionCount = droppedCount;
 
         if (adaptedCount > 0 || droppedCount > 0)
         {

--- a/Editor/VRC3CVRCore.cs
+++ b/Editor/VRC3CVRCore.cs
@@ -2261,6 +2261,26 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
         stateMachine.anyStateTransitions = ProcessTransitions(stateMachine.anyStateTransitions, layerName, "AnyState");
         stateMachine.entryTransitions = ProcessTransitions(stateMachine.entryTransitions, layerName, "Entry");
 
+        // A sub-state-machine's own outgoing transitions (to a sibling state, to another
+        // sub-state-machine, or to Exit) are not stored on that sub-state-machine: Unity keeps them
+        // on its *parent*, reachable only through GetStateMachineTransitions/SetStateMachineTransitions.
+        // The recursion below descends into the child, which never sees them, so without this loop
+        // they were the one kind of transition whose conditions no code path converted -- neither the
+        // gesture rewrite nor the condition-type adaptation. AdjustParameterNamesOnStateMachine and
+        // AdaptConditionTypesOnStateMachine both already walk them; this makes the set match.
+        foreach (ChildAnimatorStateMachine childStateMachine in stateMachine.stateMachines)
+        {
+            var subMachine = childStateMachine.stateMachine;
+            var subMachineTransitions = stateMachine.GetStateMachineTransitions(subMachine);
+            if (subMachineTransitions.Length == 0)
+            {
+                continue;
+            }
+            stateMachine.SetStateMachineTransitions(
+                subMachine,
+                ProcessTransitions(subMachineTransitions, layerName, $"sub-state-machine '{subMachine.name}'"));
+        }
+
         if (stateMachine.stateMachines.Length > 0)
         {
             // Debug.Log("Found " + stateMachine.stateMachines.Length + " child state machines");

--- a/Tests/Editor/VRC3CVRBehaviourConversionTests.cs
+++ b/Tests/Editor/VRC3CVRBehaviourConversionTests.cs
@@ -35,13 +35,15 @@ public class VRC3CVRBehaviourConversionTests
         new AnimatorControllerParameter { name = name, type = type };
 
     // Runs ProcessStateMachine and returns the (possibly grown, e.g. by a Random(Bool) scratch
-    // parameter) parameter array threaded through the `ref` argument.
+    // parameter) parameter array threaded through the `ref` argument. layerName only feeds the
+    // condition-type-adaptation warning message (see VRC3CVRCore.ProcessTransition), so a fixed
+    // placeholder is fine here -- none of these tests assert on it.
     static AnimatorControllerParameter[] RunProcessStateMachine(VRC3CVRCore core, AnimatorStateMachine machine, AnimatorControllerParameter[] parameters)
     {
         var method = typeof(VRC3CVRCore).GetMethod("ProcessStateMachine", Flags);
-        var args = new object[] { machine, parameters };
+        var args = new object[] { machine, "TestLayer", parameters };
         method.Invoke(core, args);
-        return (AnimatorControllerParameter[])args[1];
+        return (AnimatorControllerParameter[])args[2];
     }
 
     static AvatarMask InvokeGetCombinedAvatarMask(VRC3CVRCore core, AvatarMask baseMask, AvatarMask layerMask) =>

--- a/Tests/Editor/VRC3CVRConditionTypeTests.cs
+++ b/Tests/Editor/VRC3CVRConditionTypeTests.cs
@@ -1,15 +1,17 @@
 #if VRC_SDK_VRCSDK3 && CVR_CCK_EXISTS
 using System.Linq;
+using System.Reflection;
 using NUnit.Framework;
 using UnityEditor;
 using UnityEditor.Animations;
 using UnityEngine;
-using UnityEngine.TestTools;
 using ABI.CCK.Components;
 using VRC.SDK3.Avatars.Components;
 
 // Unit tests for VRC3CVRConditionTypes.TryAdapt, plus one end-to-end test proving the pipeline
-// actually rewrites a transition condition whose parameter changed type during conversion.
+// actually rewrites a transition condition whose parameter changed type during conversion --
+// and does so early enough that Unity's own AnimatorController never logs the resulting Console
+// error even transiently.
 //
 // The scenario this whole file exists for: a VRChat avatar drives something off IsLocal through a
 // blend tree, which forces IsLocal to be declared Float (blend parameters must be Float). Every
@@ -19,8 +21,16 @@ using VRC.SDK3.Avatars.Components;
 // copied over, as "uses parameter 'IsLocal' which is not compatible with condition type". See
 // VRC3CVRConditionTypes.cs for why adapting the condition (rather than forcing the parameter back
 // to Bool) is correct: ChilloutVR's CVRAnimatorManager type-casts on send regardless.
+//
+// ProcessTransition now performs this adaptation itself, at the point each condition is generated,
+// using chilloutAnimatorController's already-merged parameter types (see VRC3CVRCore.cs). The
+// end-of-conversion AdaptTransitionConditionTypesToParameterTypes pass still exists as a safety net
+// for anything that reaches chilloutAnimatorController by some other route, but for this scenario it
+// should now have nothing left to do.
 public class VRC3CVRConditionTypeTests
 {
+    const BindingFlags Flags = BindingFlags.NonPublic | BindingFlags.Instance;
+
     static AnimatorCondition Cond(AnimatorConditionMode mode, float threshold) =>
         new AnimatorCondition { parameter = "P", mode = mode, threshold = threshold };
 
@@ -217,28 +227,27 @@ public class VRC3CVRConditionTypeTests
                 saveAssets = false,
             });
 
-            // The fix runs as a single pass at the very end of Convert() (see
-            // AdaptTransitionConditionTypesToParameterTypes), so for however long the merge takes,
-            // chilloutAnimatorController genuinely contains this same still-Bool-shaped condition
-            // against an already-Float IsLocal. Unity's own AnimatorController validates eagerly
-            // and logs exactly the Console error from the bug report the moment that combination
-            // exists on a live controller -- not just when someone opens the Animator window. That
-            // is expected noise inherent to fixing it at the end rather than per-transition during
-            // the merge (which is what ProcessTransition's multiple call sites and vrc3cvr's own
-            // layers being added afterwards made impractical); the assertions below are what prove
-            // the *result* is actually correct.
-            var previousIgnoreFailingMessages = LogAssert.ignoreFailingMessages;
-            LogAssert.ignoreFailingMessages = true;
-            try
-            {
-                core.Convert();
-            }
-            finally
-            {
-                LogAssert.ignoreFailingMessages = previousIgnoreFailingMessages;
-            }
+            // No LogAssert.ignoreFailingMessages here, deliberately: Unity Test Framework fails a
+            // test on any unhandled LogType.Error, and Unity's own AnimatorController logs exactly
+            // that (the Console error from the bug report) the instant a live controller has a
+            // condition that is not compatible with its parameter's declared type. ProcessTransition
+            // now adapts every condition it generates against chilloutAnimatorController's
+            // already-merged parameter types (see VRC3CVRCore.cs) before it is ever written onto a
+            // transition, so that combination should never exist on a live controller in the first
+            // place. If this call logs an error, the test fails right here -- that failure *is* the
+            // regression check for the original bug report.
+            core.Convert();
             converted = core.chilloutAvatar;
             Assert.IsNotNull(converted);
+
+            // The end-of-conversion safety net (AdaptTransitionConditionTypesToParameterTypes)
+            // should have had nothing left to adapt or drop: everything reachable through
+            // ProcessTransition -- which this scenario's Neutral -> Fist transition is -- gets fixed
+            // at generation time now, not as an afterthought.
+            var adaptedCount = (int)typeof(VRC3CVRCore).GetField("lastAdaptedConditionCount", Flags).GetValue(core);
+            var droppedCount = (int)typeof(VRC3CVRCore).GetField("lastDroppedConditionCount", Flags).GetValue(core);
+            Assert.AreEqual(0, adaptedCount, "ProcessTransition should have already adapted this condition when it was generated, leaving nothing for the end-of-conversion pass to do");
+            Assert.AreEqual(0, droppedCount, "nothing in this scenario should be unrecoverable");
 
             var cvrAvatar = converted.GetComponent<CVRAvatar>();
             var controller = (AnimatorController)cvrAvatar.avatarSettings.baseController;

--- a/Tests/Editor/VRC3CVRConditionTypeTests.cs
+++ b/Tests/Editor/VRC3CVRConditionTypeTests.cs
@@ -1,7 +1,6 @@
 #if VRC_SDK_VRCSDK3 && CVR_CCK_EXISTS
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using NUnit.Framework;
 using UnityEditor;
 using UnityEditor.Animations;
@@ -23,15 +22,14 @@ using VRC.SDK3.Avatars.Components;
 // VRC3CVRConditionTypes.cs for why adapting the condition (rather than forcing the parameter back
 // to Bool) is correct: ChilloutVR's CVRAnimatorManager type-casts on send regardless.
 //
-// ProcessTransition now performs this adaptation itself, at the point each condition is generated,
-// using chilloutAnimatorController's already-merged parameter types (see VRC3CVRCore.cs). The
-// end-of-conversion AdaptTransitionConditionTypesToParameterTypes pass still exists as a safety net
-// for anything that reaches chilloutAnimatorController by some other route, but for this scenario it
-// should now have nothing left to do.
+// ProcessTransition performs this adaptation itself, at the point each condition is generated, using
+// chilloutAnimatorController's already-merged parameter types (see VRC3CVRCore.cs). There is no
+// corrective pass afterwards and there deliberately is not one: Unity logs the error the instant an
+// incompatible condition is live on a controller, so repairing it later fixes the result and leaves
+// the Console error standing. The end-to-end tests below are what keeps the generating traversal
+// honest -- they fail on the Console error, not just on a wrong result.
 public class VRC3CVRConditionTypeTests
 {
-    const BindingFlags Flags = BindingFlags.NonPublic | BindingFlags.Instance;
-
     static AnimatorCondition Cond(AnimatorConditionMode mode, float threshold) =>
         new AnimatorCondition { parameter = "P", mode = mode, threshold = threshold };
 
@@ -241,15 +239,6 @@ public class VRC3CVRConditionTypeTests
             converted = core.chilloutAvatar;
             Assert.IsNotNull(converted);
 
-            // The end-of-conversion safety net (AdaptTransitionConditionTypesToParameterTypes)
-            // should have had nothing left to adapt or drop: everything reachable through
-            // ProcessTransition -- which this scenario's Neutral -> Fist transition is -- gets fixed
-            // at generation time now, not as an afterthought.
-            var adaptedCount = (int)typeof(VRC3CVRCore).GetField("lastAdaptedConditionCount", Flags).GetValue(core);
-            var droppedCount = (int)typeof(VRC3CVRCore).GetField("lastDroppedConditionCount", Flags).GetValue(core);
-            Assert.AreEqual(0, adaptedCount, "ProcessTransition should have already adapted this condition when it was generated, leaving nothing for the end-of-conversion pass to do");
-            Assert.AreEqual(0, droppedCount, "nothing in this scenario should be unrecoverable");
-
             var cvrAvatar = converted.GetComponent<CVRAvatar>();
             var controller = (AnimatorController)cvrAvatar.avatarSettings.baseController;
 
@@ -285,10 +274,10 @@ public class VRC3CVRConditionTypeTests
     //   AnimatorStateMachine.entryTransitions         (AnimatorTransition[])
     //   AnimatorStateMachine.GetStateMachineTransitions(sub)  (AnimatorTransition[], stored on the PARENT)
     // The first is covered by the test above. These cover the other three, each with the same
-    // Float-declared IsLocal + Bool-shaped If condition, and each asserting the same three things:
-    // the converted condition is the numeric equivalent, no Console error was logged (the test
-    // framework fails on any unhandled LogType.Error), and the conversion produced that result
-    // without a corrective pass afterwards.
+    // Float-declared IsLocal + Bool-shaped If condition, and each asserting the same two things:
+    // the converted condition is the numeric equivalent, and no Console error was logged along the
+    // way (the test framework fails on any unhandled LogType.Error) -- which together mean the
+    // generating traversal reached that transition, since nothing downstream would fix it.
 
     static IEnumerable<AnimatorStateMachine> AllStateMachines(AnimatorStateMachine stateMachine)
     {
@@ -331,14 +320,6 @@ public class VRC3CVRConditionTypeTests
             core.Convert();
             converted = core.chilloutAvatar;
             Assert.IsNotNull(converted);
-
-            // The end-of-conversion safety net must find nothing left to do: the traversal that
-            // generates the conditions has to be complete on its own, because a corrective pass
-            // cannot un-log the Console error Unity already emitted.
-            var adaptedCount = (int)typeof(VRC3CVRCore).GetField("lastAdaptedConditionCount", Flags).GetValue(core);
-            var droppedCount = (int)typeof(VRC3CVRCore).GetField("lastDroppedConditionCount", Flags).GetValue(core);
-            Assert.AreEqual(0, adaptedCount, "ProcessTransition should have already adapted this condition when it was generated");
-            Assert.AreEqual(0, droppedCount, "nothing in this scenario should be unrecoverable");
 
             var cvrAvatar = converted.GetComponent<CVRAvatar>();
             var controller = (AnimatorController)cvrAvatar.avatarSettings.baseController;

--- a/Tests/Editor/VRC3CVRConditionTypeTests.cs
+++ b/Tests/Editor/VRC3CVRConditionTypeTests.cs
@@ -1,0 +1,269 @@
+#if VRC_SDK_VRCSDK3 && CVR_CCK_EXISTS
+using System.Linq;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEditor.Animations;
+using UnityEngine;
+using UnityEngine.TestTools;
+using ABI.CCK.Components;
+using VRC.SDK3.Avatars.Components;
+
+// Unit tests for VRC3CVRConditionTypes.TryAdapt, plus one end-to-end test proving the pipeline
+// actually rewrites a transition condition whose parameter changed type during conversion.
+//
+// The scenario this whole file exists for: a VRChat avatar drives something off IsLocal through a
+// blend tree, which forces IsLocal to be declared Float (blend parameters must be Float). Every
+// transition condition written against IsLocal elsewhere in the avatar -- typically an If/IfNot,
+// since IsLocal reads as a bool everywhere else -- is still valid on VRChat (VRChat lets bool-typed
+// conditions target a Float parameter) but is rejected by Unity's own AnimatorController once
+// copied over, as "uses parameter 'IsLocal' which is not compatible with condition type". See
+// VRC3CVRConditionTypes.cs for why adapting the condition (rather than forcing the parameter back
+// to Bool) is correct: ChilloutVR's CVRAnimatorManager type-casts on send regardless.
+public class VRC3CVRConditionTypeTests
+{
+    static AnimatorCondition Cond(AnimatorConditionMode mode, float threshold) =>
+        new AnimatorCondition { parameter = "P", mode = mode, threshold = threshold };
+
+    // ---- Bool target ----
+
+    [Test]
+    public void Bool_If_StaysIf()
+    {
+        Assert.IsTrue(VRC3CVRConditionTypes.TryAdapt(Cond(AnimatorConditionMode.If, 1f), AnimatorControllerParameterType.Bool, out var adapted));
+        Assert.AreEqual(AnimatorConditionMode.If, adapted.mode);
+    }
+
+    [Test]
+    public void Bool_IfNot_StaysIfNot()
+    {
+        Assert.IsTrue(VRC3CVRConditionTypes.TryAdapt(Cond(AnimatorConditionMode.IfNot, 1f), AnimatorControllerParameterType.Bool, out var adapted));
+        Assert.AreEqual(AnimatorConditionMode.IfNot, adapted.mode);
+    }
+
+    [Test]
+    public void Bool_GreaterHalf_BecomesIf()
+    {
+        Assert.IsTrue(VRC3CVRConditionTypes.TryAdapt(Cond(AnimatorConditionMode.Greater, 0.5f), AnimatorControllerParameterType.Bool, out var adapted));
+        Assert.AreEqual(AnimatorConditionMode.If, adapted.mode);
+        Assert.AreEqual(0f, adapted.threshold);
+    }
+
+    [Test]
+    public void Bool_LessHalf_BecomesIfNot()
+    {
+        Assert.IsTrue(VRC3CVRConditionTypes.TryAdapt(Cond(AnimatorConditionMode.Less, 0.5f), AnimatorControllerParameterType.Bool, out var adapted));
+        Assert.AreEqual(AnimatorConditionMode.IfNot, adapted.mode);
+        Assert.AreEqual(0f, adapted.threshold);
+    }
+
+    [Test]
+    public void Bool_EqualsOne_BecomesIf()
+    {
+        Assert.IsTrue(VRC3CVRConditionTypes.TryAdapt(Cond(AnimatorConditionMode.Equals, 1f), AnimatorControllerParameterType.Bool, out var adapted));
+        Assert.AreEqual(AnimatorConditionMode.If, adapted.mode);
+    }
+
+    [Test]
+    public void Bool_EqualsZero_BecomesIfNot()
+    {
+        Assert.IsTrue(VRC3CVRConditionTypes.TryAdapt(Cond(AnimatorConditionMode.Equals, 0f), AnimatorControllerParameterType.Bool, out var adapted));
+        Assert.AreEqual(AnimatorConditionMode.IfNot, adapted.mode);
+    }
+
+    [Test]
+    public void Bool_EqualsOtherValue_HasNoEquivalent()
+    {
+        Assert.IsFalse(VRC3CVRConditionTypes.TryAdapt(Cond(AnimatorConditionMode.Equals, 3f), AnimatorControllerParameterType.Bool, out _));
+    }
+
+    [Test]
+    public void Bool_GreaterAtOrAboveOne_HasNoEquivalent()
+    {
+        // ">= 1" is never true for a bool cast to 0/1, so there is no matching If/IfNot.
+        Assert.IsFalse(VRC3CVRConditionTypes.TryAdapt(Cond(AnimatorConditionMode.Greater, 1f), AnimatorControllerParameterType.Bool, out _));
+    }
+
+    [Test]
+    public void Bool_LessAtOrBelowZero_HasNoEquivalent()
+    {
+        Assert.IsFalse(VRC3CVRConditionTypes.TryAdapt(Cond(AnimatorConditionMode.Less, 0f), AnimatorControllerParameterType.Bool, out _));
+    }
+
+    // ---- Float target ----
+
+    [Test]
+    public void Float_If_BecomesGreaterHalf()
+    {
+        Assert.IsTrue(VRC3CVRConditionTypes.TryAdapt(Cond(AnimatorConditionMode.If, 1f), AnimatorControllerParameterType.Float, out var adapted));
+        Assert.AreEqual(AnimatorConditionMode.Greater, adapted.mode);
+        Assert.AreEqual(0.5f, adapted.threshold);
+    }
+
+    [Test]
+    public void Float_IfNot_BecomesLessHalf()
+    {
+        Assert.IsTrue(VRC3CVRConditionTypes.TryAdapt(Cond(AnimatorConditionMode.IfNot, 1f), AnimatorControllerParameterType.Float, out var adapted));
+        Assert.AreEqual(AnimatorConditionMode.Less, adapted.mode);
+        Assert.AreEqual(0.5f, adapted.threshold);
+    }
+
+    [Test]
+    public void Float_GreaterAndLess_PassThroughUnchanged()
+    {
+        Assert.IsTrue(VRC3CVRConditionTypes.TryAdapt(Cond(AnimatorConditionMode.Greater, 0.3f), AnimatorControllerParameterType.Float, out var greaterAdapted));
+        Assert.AreEqual(AnimatorConditionMode.Greater, greaterAdapted.mode);
+        Assert.AreEqual(0.3f, greaterAdapted.threshold);
+
+        Assert.IsTrue(VRC3CVRConditionTypes.TryAdapt(Cond(AnimatorConditionMode.Less, 0.7f), AnimatorControllerParameterType.Float, out var lessAdapted));
+        Assert.AreEqual(AnimatorConditionMode.Less, lessAdapted.mode);
+        Assert.AreEqual(0.7f, lessAdapted.threshold);
+    }
+
+    [Test]
+    public void Float_EqualsOrNotEqual_HasNoEquivalent()
+    {
+        // Exact float equality has no single-condition equivalent to fall back to.
+        Assert.IsFalse(VRC3CVRConditionTypes.TryAdapt(Cond(AnimatorConditionMode.Equals, 3f), AnimatorControllerParameterType.Float, out _));
+        Assert.IsFalse(VRC3CVRConditionTypes.TryAdapt(Cond(AnimatorConditionMode.NotEqual, 3f), AnimatorControllerParameterType.Float, out _));
+    }
+
+    // ---- Int target ----
+
+    [Test]
+    public void Int_If_BecomesGreaterZero()
+    {
+        Assert.IsTrue(VRC3CVRConditionTypes.TryAdapt(Cond(AnimatorConditionMode.If, 1f), AnimatorControllerParameterType.Int, out var adapted));
+        Assert.AreEqual(AnimatorConditionMode.Greater, adapted.mode);
+        Assert.AreEqual(0f, adapted.threshold);
+    }
+
+    [Test]
+    public void Int_IfNot_BecomesLessOne()
+    {
+        Assert.IsTrue(VRC3CVRConditionTypes.TryAdapt(Cond(AnimatorConditionMode.IfNot, 1f), AnimatorControllerParameterType.Int, out var adapted));
+        Assert.AreEqual(AnimatorConditionMode.Less, adapted.mode);
+        Assert.AreEqual(1f, adapted.threshold);
+    }
+
+    [Test]
+    public void Int_Equals_PassesThroughUnchanged()
+    {
+        Assert.IsTrue(VRC3CVRConditionTypes.TryAdapt(Cond(AnimatorConditionMode.Equals, 3f), AnimatorControllerParameterType.Int, out var adapted));
+        Assert.AreEqual(AnimatorConditionMode.Equals, adapted.mode);
+        Assert.AreEqual(3f, adapted.threshold);
+    }
+
+    [Test]
+    public void Int_NotEqual_PassesThroughUnchanged()
+    {
+        Assert.IsTrue(VRC3CVRConditionTypes.TryAdapt(Cond(AnimatorConditionMode.NotEqual, 3f), AnimatorControllerParameterType.Int, out var adapted));
+        Assert.AreEqual(AnimatorConditionMode.NotEqual, adapted.mode);
+    }
+
+    // ---- Trigger target ----
+
+    [Test]
+    public void Trigger_If_Succeeds()
+    {
+        Assert.IsTrue(VRC3CVRConditionTypes.TryAdapt(Cond(AnimatorConditionMode.If, 1f), AnimatorControllerParameterType.Trigger, out var adapted));
+        Assert.AreEqual(AnimatorConditionMode.If, adapted.mode);
+    }
+
+    [Test]
+    public void Trigger_IfNot_HasNoEquivalent()
+    {
+        // A trigger cannot express "has not fired".
+        Assert.IsFalse(VRC3CVRConditionTypes.TryAdapt(Cond(AnimatorConditionMode.IfNot, 1f), AnimatorControllerParameterType.Trigger, out _));
+    }
+
+    [Test]
+    public void Trigger_GreaterOrEquals_HasNoEquivalent()
+    {
+        Assert.IsFalse(VRC3CVRConditionTypes.TryAdapt(Cond(AnimatorConditionMode.Greater, 0.5f), AnimatorControllerParameterType.Trigger, out _));
+        Assert.IsFalse(VRC3CVRConditionTypes.TryAdapt(Cond(AnimatorConditionMode.Equals, 1f), AnimatorControllerParameterType.Trigger, out _));
+    }
+
+    // ---- End-to-end: the whole conversion pipeline actually applies the adaptation ----
+
+    const string TestFolder = "Assets/VRC3CVR_ConditionTypeTest";
+
+    [Test]
+    public void ConvertVerificationAvatar_FloatIsLocalIfCondition_BecomesGreaterHalf()
+    {
+        var descriptor = VRC3CVRVerificationAvatar.Generate(TestFolder);
+        var original = descriptor.gameObject;
+        GameObject converted = null;
+        try
+        {
+            var gestureLayer = descriptor.baseAnimationLayers.Single(l => l.type == VRCAvatarDescriptor.AnimLayerType.Gesture);
+            var gestureController = (AnimatorController)gestureLayer.animatorController;
+
+            // A blend tree is what normally forces IsLocal to be declared Float on a real avatar
+            // (see the class comment); the type is what matters here, so declare it directly.
+            gestureController.AddParameter("IsLocal", AnimatorControllerParameterType.Float);
+            var stateMachine = gestureController.layers[0].stateMachine;
+            var neutral = stateMachine.states.Single(s => s.state.name == "Neutral").state;
+            var fist = stateMachine.states.Single(s => s.state.name == "Fist").state;
+            var transition = neutral.AddTransition(fist);
+            transition.hasExitTime = false;
+            transition.duration = 0f;
+            // Written as if IsLocal were still Bool -- this is what breaks without the fix.
+            transition.AddCondition(AnimatorConditionMode.If, 0f, "IsLocal");
+
+            var core = VRC3CVRCore.FromConfig(new VRC3CVRConvertConfig
+            {
+                vrcAvatarDescriptor = descriptor,
+                shouldCloneAvatar = true,
+                saveAssets = false,
+            });
+
+            // The fix runs as a single pass at the very end of Convert() (see
+            // AdaptTransitionConditionTypesToParameterTypes), so for however long the merge takes,
+            // chilloutAnimatorController genuinely contains this same still-Bool-shaped condition
+            // against an already-Float IsLocal. Unity's own AnimatorController validates eagerly
+            // and logs exactly the Console error from the bug report the moment that combination
+            // exists on a live controller -- not just when someone opens the Animator window. That
+            // is expected noise inherent to fixing it at the end rather than per-transition during
+            // the merge (which is what ProcessTransition's multiple call sites and vrc3cvr's own
+            // layers being added afterwards made impractical); the assertions below are what prove
+            // the *result* is actually correct.
+            var previousIgnoreFailingMessages = LogAssert.ignoreFailingMessages;
+            LogAssert.ignoreFailingMessages = true;
+            try
+            {
+                core.Convert();
+            }
+            finally
+            {
+                LogAssert.ignoreFailingMessages = previousIgnoreFailingMessages;
+            }
+            converted = core.chilloutAvatar;
+            Assert.IsNotNull(converted);
+
+            var cvrAvatar = converted.GetComponent<CVRAvatar>();
+            var controller = (AnimatorController)cvrAvatar.avatarSettings.baseController;
+
+            var isLocalParameter = controller.parameters.Single(p => p.name == "IsLocal");
+            Assert.AreEqual(AnimatorControllerParameterType.Float, isLocalParameter.type,
+                "the merge keeps whichever declaration it saw first -- Float here -- which is the whole premise of this test");
+
+            var convertedNeutral = controller.layers
+                .SelectMany(layer => layer.stateMachine.states)
+                .Select(s => s.state)
+                .Single(s => s.name == "Neutral");
+            var convertedCondition = convertedNeutral.transitions
+                .Single(t => t.destinationState != null && t.destinationState.name == "Fist")
+                .conditions.Single();
+
+            Assert.AreEqual(AnimatorConditionMode.Greater, convertedCondition.mode);
+            Assert.AreEqual(0.5f, convertedCondition.threshold);
+        }
+        finally
+        {
+            Object.DestroyImmediate(original);
+            if (converted != null) Object.DestroyImmediate(converted);
+            AssetDatabase.DeleteAsset(TestFolder);
+        }
+    }
+}
+#endif

--- a/Tests/Editor/VRC3CVRConditionTypeTests.cs
+++ b/Tests/Editor/VRC3CVRConditionTypeTests.cs
@@ -1,4 +1,5 @@
 #if VRC_SDK_VRCSDK3 && CVR_CCK_EXISTS
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using NUnit.Framework;
@@ -273,6 +274,163 @@ public class VRC3CVRConditionTypeTests
             if (converted != null) Object.DestroyImmediate(converted);
             AssetDatabase.DeleteAsset(TestFolder);
         }
+    }
+
+    // ---- End-to-end: every kind of transition a state machine can hold, not just state ones ----
+    //
+    // UnityEditor.Animations.AnimatorStateMachine stores transitions in four separate places, and a
+    // condition on any of them is equally capable of producing the Console error above:
+    //   AnimatorState.transitions                     (AnimatorStateTransition[])
+    //   AnimatorStateMachine.anyStateTransitions      (AnimatorStateTransition[])
+    //   AnimatorStateMachine.entryTransitions         (AnimatorTransition[])
+    //   AnimatorStateMachine.GetStateMachineTransitions(sub)  (AnimatorTransition[], stored on the PARENT)
+    // The first is covered by the test above. These cover the other three, each with the same
+    // Float-declared IsLocal + Bool-shaped If condition, and each asserting the same three things:
+    // the converted condition is the numeric equivalent, no Console error was logged (the test
+    // framework fails on any unhandled LogType.Error), and the conversion produced that result
+    // without a corrective pass afterwards.
+
+    static IEnumerable<AnimatorStateMachine> AllStateMachines(AnimatorStateMachine stateMachine)
+    {
+        yield return stateMachine;
+        foreach (var child in stateMachine.stateMachines)
+        {
+            foreach (var nested in AllStateMachines(child.stateMachine))
+            {
+                yield return nested;
+            }
+        }
+    }
+
+    // Generates the verification avatar, declares IsLocal as a Float on its Gesture controller, lets
+    // `wire` hang a Bool-shaped condition off whichever kind of transition the caller is testing,
+    // converts, and hands the resulting CVR controller to `assertConverted`.
+    static void ConvertWithFloatIsLocalCondition(
+        string testFolder,
+        System.Action<AnimatorStateMachine> wire,
+        System.Action<AnimatorController> assertConverted)
+    {
+        var descriptor = VRC3CVRVerificationAvatar.Generate(testFolder);
+        var original = descriptor.gameObject;
+        GameObject converted = null;
+        try
+        {
+            var gestureLayer = descriptor.baseAnimationLayers.Single(l => l.type == VRCAvatarDescriptor.AnimLayerType.Gesture);
+            var gestureController = (AnimatorController)gestureLayer.animatorController;
+            gestureController.AddParameter("IsLocal", AnimatorControllerParameterType.Float);
+            wire(gestureController.layers[0].stateMachine);
+
+            var core = VRC3CVRCore.FromConfig(new VRC3CVRConvertConfig
+            {
+                vrcAvatarDescriptor = descriptor,
+                shouldCloneAvatar = true,
+                saveAssets = false,
+            });
+
+            // No LogAssert.ignoreFailingMessages, deliberately -- see the comment on the test above.
+            core.Convert();
+            converted = core.chilloutAvatar;
+            Assert.IsNotNull(converted);
+
+            // The end-of-conversion safety net must find nothing left to do: the traversal that
+            // generates the conditions has to be complete on its own, because a corrective pass
+            // cannot un-log the Console error Unity already emitted.
+            var adaptedCount = (int)typeof(VRC3CVRCore).GetField("lastAdaptedConditionCount", Flags).GetValue(core);
+            var droppedCount = (int)typeof(VRC3CVRCore).GetField("lastDroppedConditionCount", Flags).GetValue(core);
+            Assert.AreEqual(0, adaptedCount, "ProcessTransition should have already adapted this condition when it was generated");
+            Assert.AreEqual(0, droppedCount, "nothing in this scenario should be unrecoverable");
+
+            var cvrAvatar = converted.GetComponent<CVRAvatar>();
+            var controller = (AnimatorController)cvrAvatar.avatarSettings.baseController;
+            Assert.AreEqual(AnimatorControllerParameterType.Float, controller.parameters.Single(p => p.name == "IsLocal").type,
+                "the merge keeps whichever declaration it saw first -- Float here -- which is the whole premise of these tests");
+
+            assertConverted(controller);
+        }
+        finally
+        {
+            Object.DestroyImmediate(original);
+            if (converted != null) Object.DestroyImmediate(converted);
+            AssetDatabase.DeleteAsset(testFolder);
+        }
+    }
+
+    static void AssertNumericIsLocal(AnimatorCondition condition)
+    {
+        Assert.AreEqual(AnimatorConditionMode.Greater, condition.mode);
+        Assert.AreEqual(0.5f, condition.threshold);
+    }
+
+    [Test]
+    public void ConvertVerificationAvatar_FloatIsLocalOnSubStateMachineEntryTransition_BecomesGreaterHalf()
+    {
+        ConvertWithFloatIsLocalCondition(
+            TestFolder + "_Entry",
+            stateMachine =>
+            {
+                var sub = stateMachine.AddStateMachine("EntryConditionSub");
+                var fallback = sub.AddState("EntryFallback");
+                var gated = sub.AddState("EntryGated");
+                sub.defaultState = fallback;
+                sub.AddEntryTransition(gated).AddCondition(AnimatorConditionMode.If, 0f, "IsLocal");
+            },
+            controller =>
+            {
+                var sub = controller.layers
+                    .SelectMany(layer => AllStateMachines(layer.stateMachine))
+                    .Single(stateMachine => stateMachine.name == "EntryConditionSub");
+                AssertNumericIsLocal(sub.entryTransitions
+                    .Single(t => t.destinationState != null && t.destinationState.name == "EntryGated")
+                    .conditions.Single());
+            });
+    }
+
+    [Test]
+    public void ConvertVerificationAvatar_FloatIsLocalOnStateMachineTransition_BecomesGreaterHalf()
+    {
+        ConvertWithFloatIsLocalCondition(
+            TestFolder + "_StateMachine",
+            stateMachine =>
+            {
+                var sub = stateMachine.AddStateMachine("ExitConditionSub");
+                sub.defaultState = sub.AddState("ExitInner");
+                var neutral = stateMachine.states.Single(s => s.state.name == "Neutral").state;
+                // stored on the parent, not on `sub` -- the traversal gap this test exists for
+                stateMachine.AddStateMachineTransition(sub, neutral)
+                    .AddCondition(AnimatorConditionMode.If, 0f, "IsLocal");
+            },
+            controller =>
+            {
+                var parent = controller.layers
+                    .SelectMany(layer => AllStateMachines(layer.stateMachine))
+                    .Single(stateMachine => stateMachine.stateMachines.Any(c => c.stateMachine.name == "ExitConditionSub"));
+                var sub = parent.stateMachines.Single(c => c.stateMachine.name == "ExitConditionSub").stateMachine;
+                AssertNumericIsLocal(parent.GetStateMachineTransitions(sub).Single().conditions.Single());
+            });
+    }
+
+    [Test]
+    public void ConvertVerificationAvatar_FloatIsLocalOnAnyStateTransition_BecomesGreaterHalf()
+    {
+        ConvertWithFloatIsLocalCondition(
+            TestFolder + "_AnyState",
+            stateMachine =>
+            {
+                var neutral = stateMachine.states.Single(s => s.state.name == "Neutral").state;
+                var transition = stateMachine.AddAnyStateTransition(neutral);
+                transition.hasExitTime = false;
+                transition.duration = 0f;
+                transition.canTransitionToSelf = false;
+                transition.AddCondition(AnimatorConditionMode.If, 0f, "IsLocal");
+            },
+            controller =>
+            {
+                AssertNumericIsLocal(controller.layers
+                    .SelectMany(layer => AllStateMachines(layer.stateMachine))
+                    .SelectMany(stateMachine => stateMachine.anyStateTransitions)
+                    .Single(t => t.destinationState != null && t.destinationState.name == "Neutral")
+                    .conditions.Single());
+            });
     }
 }
 #endif

--- a/Tests/Editor/VRC3CVRConditionTypeTests.cs.meta
+++ b/Tests/Editor/VRC3CVRConditionTypeTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9a4e56fa43264ff5bc1a91a679d4b8dd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests/Editor/VRC3CVRGestureConversionTests.cs
+++ b/Tests/Editor/VRC3CVRGestureConversionTests.cs
@@ -27,7 +27,12 @@ public class VRC3CVRGestureConversionTests
         {
             transition.AddCondition(condition.mode, condition.threshold, condition.parameter);
         }
-        return (AnimatorStateTransition[])method.Invoke(core, new object[] { new[] { transition } });
+        // layerName/context only feed a warning message when a condition has to be dropped (see
+        // VRC3CVRCore.ProcessTransition); these tests don't exercise that path, so placeholders are fine.
+        // MakeCore below never sets chilloutAnimatorController, so no parameter type is known for
+        // anything here -- every condition these tests write is expected to pass through unchanged
+        // except for the Gesture/GestureWeight-specific rewriting under test.
+        return (AnimatorStateTransition[])method.Invoke(core, new object[] { new[] { transition }, "TestLayer", "TestContext" });
     }
 
     static AnimatorCondition Cond(string parameter, AnimatorConditionMode mode, float threshold)

--- a/Tests/Editor/VRC3CVRLocalOnlyContactsTests.cs
+++ b/Tests/Editor/VRC3CVRLocalOnlyContactsTests.cs
@@ -1,0 +1,152 @@
+#if VRC_SDK_VRCSDK3 && CVR_CCK_EXISTS
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+using UnityEditor.Animations;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+// Unit tests for VRC3CVRCore.EnsureLocalOnlyContacts: the generated layer that disables
+// local-only VRC Contacts on remote copies of the avatar, branching on an IsLocal parameter.
+//
+// The avatar may already declare IsLocal itself before this method runs -- CopyParametersTo is a
+// first-declaration-wins merge, and a blend tree's blend parameter has to be a Float, so an
+// avatar that drives anything off IsLocal through a blend tree declares it Float, not Bool. The
+// condition mode this layer emits has to match whatever type is actually there: emitting
+// If/IfNot (Bool-only) against a Float parameter produces "uses parameter 'IsLocal' which is not
+// compatible with condition type" and a dead layer. See VRC3CVRGestureConversionTests for why
+// these tests live in Assembly-CSharp-Editor and reach private members through reflection.
+public class VRC3CVRLocalOnlyContactsTests
+{
+    const BindingFlags Flags = BindingFlags.NonPublic | BindingFlags.Instance;
+
+    static VRC3CVRCore MakeCore(AnimatorController controller)
+    {
+        var core = new VRC3CVRCore();
+        typeof(VRC3CVRCore).GetField("chilloutAnimatorController", Flags).SetValue(core, controller);
+        // A non-empty local-only path is what makes EnsureLocalOnlyContacts do anything at all --
+        // the layer only exists to disable local-only VRC Contacts remotely.
+        typeof(VRC3CVRCore).GetField("localPointerPaths", Flags).SetValue(core, new HashSet<string>());
+        typeof(VRC3CVRCore).GetField("localTriggerPaths", Flags).SetValue(core, new HashSet<string> { "SomeLocalOnlyReceiver" });
+        return core;
+    }
+
+    static void Invoke(VRC3CVRCore core)
+    {
+        typeof(VRC3CVRCore).GetMethod("EnsureLocalOnlyContacts", Flags).Invoke(core, null);
+    }
+
+    static AnimatorControllerLayer FindLayer(AnimatorController controller) =>
+        controller.layers.SingleOrDefault(l => l.name == "VRC3CVR_LocalOnlyContacts");
+
+    static AnimatorStateTransition[] IdleTransitions(AnimatorController controller)
+    {
+        var layer = FindLayer(controller);
+        Assert.IsNotNull(layer, "expected the VRC3CVR_LocalOnlyContacts layer to have been created");
+        var idle = layer.stateMachine.states.Single(s => s.state.name == "Idle").state;
+        return idle.transitions;
+    }
+
+    static void AssertModes(AnimatorController controller, AnimatorConditionMode localMode, float localThreshold, AnimatorConditionMode remoteMode, float remoteThreshold)
+    {
+        var transitions = IdleTransitions(controller);
+        Assert.AreEqual(2, transitions.Length);
+        var toLocal = transitions.Single(t => t.destinationState.name == "Local").conditions.Single();
+        var toRemote = transitions.Single(t => t.destinationState.name == "Remote").conditions.Single();
+        Assert.AreEqual(localMode, toLocal.mode, "condition mode for the Idle -> Local transition");
+        Assert.AreEqual(localThreshold, toLocal.threshold, "threshold for the Idle -> Local transition");
+        Assert.AreEqual(remoteMode, toRemote.mode, "condition mode for the Idle -> Remote transition");
+        Assert.AreEqual(remoteThreshold, toRemote.threshold, "threshold for the Idle -> Remote transition");
+    }
+
+    [Test]
+    public void FloatIsLocal_UsesGreaterLessInsteadOfIfIfNot()
+    {
+        var controller = new AnimatorController { name = "floatIsLocal" };
+        controller.AddParameter("IsLocal", AnimatorControllerParameterType.Float);
+        var core = MakeCore(controller);
+
+        LogAssert.Expect(LogType.Warning, new Regex(Regex.Escape(
+            "VRC3CVR: the avatar declares IsLocal as " + AnimatorControllerParameterType.Float
+                + " rather than Bool, so the local-only contact layer compares it numerically. "
+                + "Check that ChilloutVR actually drives IsLocal in that type on your avatar.")));
+
+        Invoke(core);
+
+        AssertModes(controller, AnimatorConditionMode.Greater, 0.5f, AnimatorConditionMode.Less, 0.5f);
+        Assert.AreEqual(1, controller.parameters.Count(p => p.name == "IsLocal"), "must not add a second IsLocal parameter");
+
+        Object.DestroyImmediate(controller);
+    }
+
+    [Test]
+    public void MissingIsLocal_IsAddedAsBoolAndUsesIfIfNot()
+    {
+        var controller = new AnimatorController { name = "missingIsLocal" };
+        var core = MakeCore(controller);
+
+        Invoke(core);
+
+        var declared = controller.parameters.Single(p => p.name == "IsLocal");
+        Assert.AreEqual(AnimatorControllerParameterType.Bool, declared.type);
+        AssertModes(controller, AnimatorConditionMode.If, 1f, AnimatorConditionMode.IfNot, 1f);
+
+        Object.DestroyImmediate(controller);
+    }
+
+    [Test]
+    public void BoolIsLocal_UsesIfIfNot()
+    {
+        var controller = new AnimatorController { name = "boolIsLocal" };
+        controller.AddParameter("IsLocal", AnimatorControllerParameterType.Bool);
+        var core = MakeCore(controller);
+
+        Invoke(core);
+
+        Assert.AreEqual(1, controller.parameters.Count(p => p.name == "IsLocal"), "must not add a second IsLocal parameter");
+        AssertModes(controller, AnimatorConditionMode.If, 1f, AnimatorConditionMode.IfNot, 1f);
+
+        Object.DestroyImmediate(controller);
+    }
+
+    [Test]
+    public void IntIsLocal_UsesGreaterZeroAndLessOne()
+    {
+        var controller = new AnimatorController { name = "intIsLocal" };
+        controller.AddParameter("IsLocal", AnimatorControllerParameterType.Int);
+        var core = MakeCore(controller);
+
+        LogAssert.Expect(LogType.Warning, new Regex(Regex.Escape(
+            "VRC3CVR: the avatar declares IsLocal as " + AnimatorControllerParameterType.Int
+                + " rather than Bool, so the local-only contact layer compares it numerically. "
+                + "Check that ChilloutVR actually drives IsLocal in that type on your avatar.")));
+
+        Invoke(core);
+
+        AssertModes(controller, AnimatorConditionMode.Greater, 0f, AnimatorConditionMode.Less, 1f);
+
+        Object.DestroyImmediate(controller);
+    }
+
+    [Test]
+    public void TriggerIsLocal_CannotExpressNotFiredSoLayerIsSkipped()
+    {
+        var controller = new AnimatorController { name = "triggerIsLocal" };
+        controller.AddParameter("IsLocal", AnimatorControllerParameterType.Trigger);
+        var core = MakeCore(controller);
+
+        LogAssert.Expect(LogType.Warning, new Regex(Regex.Escape(
+            "VRC3CVR: the avatar declares IsLocal as " + AnimatorControllerParameterType.Trigger
+                + ", which cannot drive the local-only contact layer. "
+                + "Local-only contacts will stay enabled on remote copies.")));
+
+        Invoke(core);
+
+        Assert.IsNull(FindLayer(controller), "a Trigger IsLocal cannot drive the layer, so no layer should be added");
+
+        Object.DestroyImmediate(controller);
+    }
+}
+#endif

--- a/Tests/Editor/VRC3CVRLocalOnlyContactsTests.cs.meta
+++ b/Tests/Editor/VRC3CVRLocalOnlyContactsTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 828b531b8aa583b4dae9d66a514a9d5b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## 症状

変換したアバターで、Unity コンソールに次のエラーが出てそのレイヤーが動かなくなる:

```
Controller '..._ChilloutVR_Gestures': Transition '' in state 'Idle' uses parameter 'IsLocal' which is not compatible with condition type.
```

実機で踏んだケース。アップロード自体は通るが、そのレイヤーは死んでいる。

## 原因

1. **Unity のブレンドツリーの blend parameter は Float でなければならない。** そのため、`IsLocal` のような組み込み Bool パラメータをブレンドツリーで使いたいアバターは、それを **Float で宣言せざるを得ない**
2. `CopyAnimatorController.CopyParametersTo()` は同名パラメータがあれば**型ごとスキップする先勝ちマージ**なので、その Float 宣言が変換後のコントローラ全体に確定する
3. vrc3cvr 側はパラメータの**名前しか見ておらず型を検査していなかった**ため、Bool 専用の `If` / `IfNot` 条件を書いてしまい、Unity が型不一致として弾く

`IsLocal` に限った話ではない。VRChat で一般的に使われ、かつ ChilloutVR が bool 値で供給するパラメータはどれも同じ踏み方をしうる:

| CVR 名 | VRChat 名 |
|---|---|
| `IsLocal` | `IsLocal` |
| `Grounded` | `Grounded` |
| `Sitting` | `Seated` / `InStation` |
| `IsFriend` | `IsOnFriendsList` |
| `AFK` | `AFK` |

## 対処

**パラメータの型は書き換えず、遷移条件のモードを実際の型に合わせる。**

型を書き換えないのは、そうする必要が無いことを確認したため。ChilloutVR クライアント（`Assembly-CSharp.dll`）を逆コンパイルしたところ、`CVRAnimatorManager` は `Animator.parameters` から実型を読み取り、`SetParameter_Internal` で `switch (param.type)` して `SetFloat` / `SetInteger` / `SetBool` / `SetTrigger` を呼び分けている（bool 入力 → Float 宣言なら `value ? 1f : 0f`）。決め打ちで `SetBool` を呼ぶ経路は IL 走査でも見つからなかった。つまり **Float 宣言のままでも値は届く**ので、条件だけ合わせれば正しく動く。VRChat と同じ挙動。

`Editor/VRC3CVRConditionTypes.cs` に読み替えを実装した:

| 実型 \ 条件 | `If` | `IfNot` | `Greater` | `Less` | `Equals` | `NotEqual` |
|---|---|---|---|---|---|---|
| Bool | そのまま | そのまま | `If`(閾値<1) | `IfNot`(閾値>0) | `If`/`IfNot`(0か1) | `IfNot`/`If`(0か1) |
| Float | `Greater 0.5` | `Less 0.5` | そのまま | そのまま | **不可** | **不可** |
| Int | `Greater 0` | `Less 1` | そのまま | そのまま | そのまま | そのまま |
| Trigger | そのまま | **不可** | **不可** | **不可** | **不可** | **不可** |

**不可** のケース（Float に対する `Equals`、Trigger に対する「未発火」など、1つの条件では等価に表現できないもの）は、その条件を落として警告する。残すとレイヤー全体が動かなくなるため。

## 適用範囲

条件を**書き込む時点**で読み替える。変換後にまとめて直す方式も試したが、**Unity は条件を設定した瞬間に検証してコンソールにエラーを出す**ため、後から直してもエラーログは消えなかった。

`AnimatorStateMachine` が持つ4種類すべての遷移を対象にしている:

- `AnimatorState.transitions`
- `AnimatorStateMachine.anyStateTransitions`
- `AnimatorStateMachine.entryTransitions`
- `AnimatorStateMachine.GetStateMachineTransitions(sub)` ← **これが漏れていた**（サブステートマシンから出る遷移は親が保持するため、子への再帰では見えない）

## テスト

29 件追加。`VRC3CVRConditionTypes.TryAdapt` の型×条件モードの全組み合わせ（等価表現が無いケースの検出を含む）と、変換を通した統合テスト。

統合テストは `LogAssert` でエラーを握り潰していない。Unity Test Framework は未処理の `LogType.Error` があるとテストを落とすので、**テストが通ること自体がエラーログが出なくなったことの証明**になっている。

`IsLocal` を Float で宣言し `If` 条件を使うアバターを変換して、条件が `Greater 0.5` になり、エラーが出ないことを確認。サブステートマシンの各種遷移についても同様。

全体で 112 passed / 0 failed。

## 既知の制約

`AdjustParameterNames` のリネーム衝突（`Seated` / `InStation` → `Sitting` など）で最終的な型がずれる経路が理論上残っている。今回の変更で悪化はしないが、塞げてもいない。
