### PR TITLE
ChilloutVR のワールド速度から VRChat 相当のアバターローカル速度を再構成する

### DIFF
--- a/Editor/VRC3CVRCore.cs
+++ b/Editor/VRC3CVRCore.cs
@@ -60,8 +60,6 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
     // This stores generated extra avatar masks based on the VRC hardcoded animator masks combined with individual layer masks.
     Dictionary<(AvatarMask, AvatarMask), AvatarMask> avatarMaskCombineCache = new Dictionary<(AvatarMask, AvatarMask), AvatarMask>();
 
-    // Tracked rather than inferred from the "VRC3CVR_" prefix: an avatar's own layer can legally
-    // carry that name, and skipping it would silently drop real content from WalkParameterNames.
     HashSet<string> generatedLayerNames = new HashSet<string>();
 
     // This mask will mask all other layer masks from the gesture animator, and is derived from the
@@ -1282,16 +1280,14 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
     // Overrides the rename rule for the duration of a WalkParameterNames pass.
     System.Func<string, string> parameterRenamer;
 
-    // Rewrites parameter references with an arbitrary mapping, reusing the AdjustParameterNames*
-    // walker because that is the only complete inventory of the places a name can hide.
+    // Reuses the AdjustParameterNames* walker: it is the only complete inventory of the places a
+    // parameter name can hide.
     //
-    // Declarations are left alone: a targeted pass repoints references while the original parameter
-    // stays declared, since it is still the client-fed input its replacement is computed from.
-    //
-    // Generated layers are skipped because their references are what their own generator chose on
-    // purpose — the magnitude layer's world-space VelocityX/Z reads are deliberate — so a later,
-    // narrower pass that happens to match them would corrupt that layer and manufacture a false
-    // "this parameter is used" signal from its own output.
+    // Declarations are left alone — the original parameter is still the client-fed input its
+    // replacement is computed from. Generated layers are skipped: their references are what their
+    // own generator chose on purpose (the magnitude layer reads world-space VelocityX/Z
+    // deliberately), so rewriting them would both corrupt that layer and manufacture a false "this
+    // parameter is used" signal out of its own output.
     void WalkParameterNames(System.Func<string, string> renamer)
     {
         parameterRenamer = renamer;

--- a/Editor/VRC3CVRCore.cs
+++ b/Editor/VRC3CVRCore.cs
@@ -1225,6 +1225,13 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
         var type = RenameParameterType.None;
         if (!string.IsNullOrEmpty(name))
         {
+            // Transition conditions, blend tree axes and AAP curve bindings call this pair directly
+            // rather than through RenameParameterNameIfNeeded, so a targeted WalkParameterNames pass
+            // has to branch here too or those call sites would stay blind to it.
+            if (parameterRenamer != null)
+            {
+                return parameterRenamer(name) != name ? RenameParameterType.Rename : RenameParameterType.None;
+            }
             var renamedName = name;
             if (parameterRenameMap.ContainsKey(name))
             {
@@ -1245,6 +1252,10 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
 
     string RenameParameterName(string name, RenameParameterType type)
     {
+        if (parameterRenamer != null)
+        {
+            return parameterRenamer(name);
+        }
         if (type.HasFlag(RenameParameterType.Rename))
         {
             name = parameterRenameMap[name];
@@ -1260,8 +1271,38 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
         return name;
     }
 
+    // Set while a targeted rename pass is running. The whole AdjustParameterNames* walker —
+    // transitions, driver tasks, blend tree axes, AAP curves, state time/speed/cycleOffset — is the
+    // only complete inventory of the places a parameter name can hide, so a second pass with a
+    // different mapping reuses it rather than growing a parallel walker that will drift.
+    System.Func<string, string> parameterRenamer;
+
+    // Layers only, deliberately: AdjustParameterNamesOnAnimator also renames the DECLARATIONS, and
+    // a targeted pass wants the references pointed elsewhere while the original parameter stays
+    // declared — VelocityX is still the client-fed input the derived value is computed from.
+    void WalkParameterNames(System.Func<string, string> renamer)
+    {
+        parameterRenamer = renamer;
+        try
+        {
+            foreach (var layer in chilloutAnimatorController.layers)
+            {
+                AdjustParameterNamesOnStateMachine(layer.stateMachine);
+            }
+        }
+        finally
+        {
+            parameterRenamer = null;
+        }
+    }
+
     void RenameParameterNameIfNeeded(ref string name)
     {
+        if (parameterRenamer != null)
+        {
+            name = parameterRenamer(name);
+            return;
+        }
         var type = GetRenameParameterType(name);
         if (type != RenameParameterType.None)
         {

--- a/Editor/VRC3CVRCore.cs
+++ b/Editor/VRC3CVRCore.cs
@@ -176,7 +176,10 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
             AdjustParameterNames();
             MakeGestureWeightFeedLayers();
             MakeVelocityMagnitudeFeedLayer();
-            MakeLocomotionVelocityFeedLayer();
+            // after AdjustParameterNames, like the feed layers above, so the names it rewrites are
+            // the final ones — and after MakeVelocityMagnitudeFeedLayer, whose own VelocityX/Z reads
+            // are the world-space ones it wants
+            RemapVelocityToAvatarLocal();
             MakeGameStateParameterStreams();
             InsertChilloutOverride();
 
@@ -3817,6 +3820,51 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
             },
         };
         chilloutAnimatorController.AddLayer(layer);
+    }
+
+    // VelocityY is deliberately untouched: the player only ever rotates about Y, so the vertical
+    // axis is the same number in world space and in avatar space. VelocityMagnitude is untouched
+    // for the same kind of reason — a magnitude has no orientation.
+    void RemapVelocityToAvatarLocal()
+    {
+        var localX = NonSyncParameterName("VelocityXLocal");
+        var localZ = NonSyncParameterName("VelocityZLocal");
+        var uses = false;
+        WalkParameterNames(name =>
+        {
+            if (name == "VelocityX")
+            {
+                uses = true;
+                return localX;
+            }
+            if (name == "VelocityZ")
+            {
+                uses = true;
+                return localZ;
+            }
+            return name;
+        });
+        if (!uses)
+        {
+            return;
+        }
+        // declared here, not by the feed layer: the feed layer's own guard is "does anything read
+        // the derived parameters", and pointing the references at them is what makes that true
+        var parameters = chilloutAnimatorController.parameters;
+        foreach (var derived in new[] { localX, localZ })
+        {
+            if (!parameters.Any(p => p.name == derived))
+            {
+                ArrayUtility.Add(ref parameters, new AnimatorControllerParameter
+                {
+                    name = derived,
+                    type = AnimatorControllerParameterType.Float,
+                    defaultFloat = 0f,
+                });
+            }
+        }
+        chilloutAnimatorController.parameters = parameters;
+        MakeLocomotionVelocityFeedLayer();
     }
 
     // ChilloutVR reports VelocityX/Y/Z in WORLD space (measured in game), while every VRChat layer

--- a/Editor/VRC3CVRCore.cs
+++ b/Editor/VRC3CVRCore.cs
@@ -176,6 +176,7 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
             AdjustParameterNames();
             MakeGestureWeightFeedLayers();
             MakeVelocityMagnitudeFeedLayer();
+            MakeLocomotionVelocityFeedLayer();
             MakeGameStateParameterStreams();
             InsertChilloutOverride();
 
@@ -3816,6 +3817,151 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
             },
         };
         chilloutAnimatorController.AddLayer(layer);
+    }
+
+    // ChilloutVR reports VelocityX/Y/Z in WORLD space (measured in game), while every VRChat layer
+    // was authored against an avatar-LOCAL VelocityX/VelocityZ. The reconstruction cannot be
+    // written back into VelocityX/Z — the client rewrites those every frame — so it lands in
+    // derived parameters and RemapVelocityToAvatarLocal points the converted layers at them.
+    //
+    // MovementX/Y give the direction: they are player-local by construction, +X right and +Y
+    // forward, matching VRChat's VelocityX/VelocityZ axes. They are NOT a unit vector — 0.5 is the
+    // walk ring and 1.0 the run ring — so only their direction is used and the magnitude comes from
+    // the world velocity, which is frame-independent. Verified in game at 0.000 m/s mean error.
+    //
+    // Both inputs are ChilloutVR synced core parameters, so this costs no sync bits and holds on
+    // remote copies as well as the wearer's.
+    void MakeLocomotionVelocityFeedLayer()
+    {
+        var parameters = chilloutAnimatorController.parameters;
+        var localX = NonSyncParameterName("VelocityXLocal");
+        var localZ = NonSyncParameterName("VelocityZLocal");
+        if (!parameters.Any(p => p.name == localX) && !parameters.Any(p => p.name == localZ))
+        {
+            // no converted layer asked for an avatar-local velocity
+            return;
+        }
+        foreach (var inputName in new[] { "VelocityX", "VelocityZ", "MovementX", "MovementY" })
+        {
+            if (!parameters.Any(p => p.name == inputName))
+            {
+                ArrayUtility.Add(ref parameters, new AnimatorControllerParameter
+                {
+                    name = inputName,
+                    type = AnimatorControllerParameterType.Float,
+                    defaultFloat = 0f,
+                });
+            }
+        }
+        foreach (var derived in new[] { localX, localZ })
+        {
+            if (!parameters.Any(p => p.name == derived))
+            {
+                ArrayUtility.Add(ref parameters, new AnimatorControllerParameter
+                {
+                    name = derived,
+                    type = AnimatorControllerParameterType.Float,
+                    defaultFloat = 0f,
+                });
+            }
+        }
+        var scratch = NonSyncParameterName("VelocityLocalCalc");
+        ArrayUtility.Add(ref parameters, new AnimatorControllerParameter
+        {
+            name = scratch,
+            type = AnimatorControllerParameterType.Float,
+            defaultFloat = 0f,
+        });
+        chilloutAnimatorController.parameters = parameters;
+
+        AnimatorDriverTask Task(AnimatorDriverTask.Operator op, string targetName, string aName, string bName, float bValue = 0f)
+        {
+            return new AnimatorDriverTask
+            {
+                op = op,
+                targetName = targetName,
+                targetType = AnimatorDriverTask.ParameterType.Float,
+                aType = AnimatorDriverTask.SourceType.Parameter,
+                aParamType = AnimatorDriverTask.ParameterType.Float,
+                aName = aName,
+                bType = bName == null ? AnimatorDriverTask.SourceType.Static : AnimatorDriverTask.SourceType.Parameter,
+                bParamType = AnimatorDriverTask.ParameterType.Float,
+                bName = bName ?? "",
+                bValue = bValue,
+            };
+        }
+
+        var tickClip = new AnimationClip { name = "VRC3CVR_LocomotionVelocityTick" };
+        tickClip.SetCurve("", typeof(Animator), NonSyncParameterName("LocomotionVelocityTick"), AnimationCurve.Constant(0f, 1f / 60f, 0f));
+        var recomputeState = new AnimatorState
+        {
+            hideFlags = HideFlags.HideInHierarchy,
+            name = "Recompute",
+            writeDefaultValues = false,
+            motion = tickClip,
+            behaviours = new StateMachineBehaviour[]
+            {
+                new AnimatorDriver
+                {
+                    hideFlags = HideFlags.HideInHierarchy,
+                    localOnly = false,
+                    EnterTasks = new List<AnimatorDriverTask>
+                    {
+                        // ground speed; the Y axis is not part of a locomotion tree's space
+                        Task(AnimatorDriverTask.Operator.Multiplication, scratch, "VelocityX", "VelocityX"),
+                        Task(AnimatorDriverTask.Operator.Multiplication, localX, "VelocityZ", "VelocityZ"),
+                        Task(AnimatorDriverTask.Operator.Addition, scratch, scratch, localX),
+                        Task(AnimatorDriverTask.Operator.Power, scratch, scratch, null, 0.5f),
+                        // the walk/run ring
+                        Task(AnimatorDriverTask.Operator.Multiplication, localZ, "MovementX", "MovementX"),
+                        Task(AnimatorDriverTask.Operator.Multiplication, localX, "MovementY", "MovementY"),
+                        Task(AnimatorDriverTask.Operator.Addition, localZ, localZ, localX),
+                        Task(AnimatorDriverTask.Operator.Power, localZ, localZ, null, 0.5f),
+                        // scale = speed / (ring + epsilon); standing still leaves speed ~0, so the
+                        // scale collapses to ~0 instead of dividing by zero
+                        Task(AnimatorDriverTask.Operator.Addition, localX, localZ, null, 0.0001f),
+                        Task(AnimatorDriverTask.Operator.Division, localX, scratch, localX),
+                        // Z first: filling X overwrites the scale both of them need
+                        Task(AnimatorDriverTask.Operator.Multiplication, localZ, "MovementY", localX),
+                        Task(AnimatorDriverTask.Operator.Multiplication, localX, "MovementX", localX),
+                    },
+                },
+            },
+        };
+        recomputeState.transitions = new AnimatorStateTransition[]
+        {
+            new AnimatorStateTransition
+            {
+                hideFlags = HideFlags.HideInHierarchy,
+                hasExitTime = true,
+                exitTime = 1f,
+                hasFixedDuration = true,
+                duration = 0f,
+                offset = 0f,
+                destinationState = recomputeState,
+            },
+        };
+        var layerName = chilloutAnimatorController.MakeUniqueLayerName("VRC3CVR_LocomotionVelocity");
+        chilloutAnimatorController.AddLayer(new AnimatorControllerLayer
+        {
+            name = layerName,
+            defaultWeight = 1f,
+            blendingMode = AnimatorLayerBlendingMode.Override,
+            avatarMask = emptyMask,
+            stateMachine = new AnimatorStateMachine
+            {
+                hideFlags = HideFlags.HideInHierarchy,
+                name = layerName,
+                entryPosition = new Vector3(0, -100),
+                exitPosition = new Vector3(0, 200),
+                anyStatePosition = new Vector3(0, -300),
+                defaultState = recomputeState,
+                states = new ChildAnimatorState[]
+                {
+                    new ChildAnimatorState { state = recomputeState, position = new Vector3(0, 0) },
+                },
+            },
+        });
     }
 
     // VRChat built-ins that ChilloutVR does not supply to the animator. The client's parameter

--- a/Editor/VRC3CVRCore.cs
+++ b/Editor/VRC3CVRCore.cs
@@ -60,6 +60,13 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
     // This stores generated extra avatar masks based on the VRC hardcoded animator masks combined with individual layer masks.
     Dictionary<(AvatarMask, AvatarMask), AvatarMask> avatarMaskCombineCache = new Dictionary<(AvatarMask, AvatarMask), AvatarMask>();
 
+    // Layers this conversion generated (feed layers, contact proxy layers, etc.), keyed by the name
+    // they actually ended up with — MakeUniqueLayerName may suffix it. NOT inferred from the
+    // "VRC3CVR_" naming convention: an original VRC avatar layer can legally be named anything,
+    // including something that happens to start with that prefix, so name-sniffing would silently
+    // skip real avatar content. Populated only through AddGeneratedLayer so no call site can forget.
+    HashSet<string> generatedLayerNames = new HashSet<string>();
+
     // This mask will mask all other layer masks from the gesture animator, and is derived from the
     // *first* layer.
     AvatarMask gestureMask;
@@ -140,6 +147,7 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
             // Clear the cache
             avatarMaskCombineCache = new Dictionary<(AvatarMask, AvatarMask), AvatarMask>();
             gestureMask = null;
+            generatedLayerNames = new HashSet<string>();
 
             // Load masks
             emptyMask = LoadMask("vrc3cvrEmptyMask.mask");
@@ -179,8 +187,9 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
             // After AdjustParameterNames, like the feed layers above, so the names it rewrites are
             // the final ones. Running after MakeVelocityMagnitudeFeedLayer does NOT require that
             // layer's literal "VelocityX"/"VelocityZ" reads to survive by luck of ordering —
-            // WalkParameterNames skips vrc3cvr's own "VRC3CVR_"-prefixed layers outright, so this
-            // pass structurally cannot see (and previously did corrupt) a feed layer's own reads.
+            // WalkParameterNames skips every layer recorded in generatedLayerNames (see
+            // AddGeneratedLayer), so this pass structurally cannot see, let alone corrupt, a feed
+            // layer's own reads, regardless of what order Convert() calls things in.
             RemapVelocityToAvatarLocal();
             MakeGameStateParameterStreams();
             InsertChilloutOverride();
@@ -205,6 +214,7 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
             // Clear the cache
             avatarMaskCombineCache = new Dictionary<(AvatarMask, AvatarMask), AvatarMask>();
             gestureMask = null;
+            generatedLayerNames = new HashSet<string>();
 
             Debug.Log("Conversion complete!");
         }
@@ -1287,16 +1297,17 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
     // a targeted pass wants the references pointed elsewhere while the original parameter stays
     // declared — VelocityX is still the client-fed input the derived value is computed from.
     //
-    // Layers vrc3cvr itself generated are skipped, identified by the "VRC3CVR_" prefix every
-    // feed/proxy layer this codebase creates uses (MakeVelocityMagnitudeFeedLayer,
-    // MakeGestureWeightFeedLayers, MakeLocomotionVelocityFeedLayer, the contact proxy/local-only
-    // layers — see the AddLayer call sites). Their parameter references are exactly what their own
-    // generator chose on purpose (e.g. the magnitude layer's literal "VelocityX"/"VelocityZ" reads
-    // are deliberately world-space); a second, narrower rename pass has no business rewriting
-    // content this same Convert() call just produced, only content carried over from the original
-    // avatar. Without this, a targeted pass whose mapping happens to match a generated layer's own
-    // reads corrupts that layer — and can manufacture a false "this parameter is used" signal from
-    // its own output, independent of what order Convert() happens to call things in.
+    // Layers vrc3cvr itself generated are skipped, via generatedLayerNames rather than by sniffing
+    // the "VRC3CVR_" name prefix: an original VRC avatar layer can legally be named anything,
+    // including something that happens to start with that prefix, and skipping it on name alone
+    // would silently drop real avatar content from the walk. Generated layers' parameter references
+    // are exactly what their own generator chose on purpose (e.g. the magnitude layer's literal
+    // "VelocityX"/"VelocityZ" reads are deliberately world-space); a second, narrower rename pass
+    // has no business rewriting content this same Convert() call just produced, only content
+    // carried over from the original avatar. Without this, a targeted pass whose mapping happens to
+    // match a generated layer's own reads corrupts that layer — and can manufacture a false "this
+    // parameter is used" signal from its own output, independent of what order Convert() happens to
+    // call things in.
     void WalkParameterNames(System.Func<string, string> renamer)
     {
         parameterRenamer = renamer;
@@ -1304,7 +1315,7 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
         {
             foreach (var layer in chilloutAnimatorController.layers)
             {
-                if (layer.name.StartsWith("VRC3CVR_"))
+                if (generatedLayerNames.Contains(layer.name))
                 {
                     continue;
                 }
@@ -1315,6 +1326,16 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
         {
             parameterRenamer = null;
         }
+    }
+
+    // The single choke point every generated layer must go through, so generatedLayerNames (see
+    // WalkParameterNames) can never miss one — a call site that used chilloutAnimatorController
+    // .AddLayer directly would silently reintroduce the corruption this exists to prevent. Keyed on
+    // layer.name as actually assigned, since MakeUniqueLayerName may have suffixed it.
+    void AddGeneratedLayer(AnimatorControllerLayer layer)
+    {
+        chilloutAnimatorController.AddLayer(layer);
+        generatedLayerNames.Add(layer.name);
     }
 
     void RenameParameterNameIfNeeded(ref string name)
@@ -3617,7 +3638,7 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
                     },
                 },
             };
-            chilloutAnimatorController.AddLayer(layer);
+            AddGeneratedLayer(layer);
         }
         chilloutAnimatorController.parameters = parameters;
     }
@@ -3714,7 +3735,7 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
                 },
             },
         };
-        chilloutAnimatorController.AddLayer(layer);
+        AddGeneratedLayer(layer);
     }
 
     // VRChat supplies VelocityMagnitude; ChilloutVR does not, so recompute it from the
@@ -3836,7 +3857,7 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
                 },
             },
         };
-        chilloutAnimatorController.AddLayer(layer);
+        AddGeneratedLayer(layer);
     }
 
     // VelocityY is deliberately untouched: the player only ever rotates about Y, so the vertical
@@ -4007,7 +4028,7 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
             },
         };
         var layerName = chilloutAnimatorController.MakeUniqueLayerName("VRC3CVR_LocomotionVelocity");
-        chilloutAnimatorController.AddLayer(new AnimatorControllerLayer
+        AddGeneratedLayer(new AnimatorControllerLayer
         {
             name = layerName,
             defaultWeight = 1f,
@@ -4597,7 +4618,7 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
             },
         };
         var layerName = chilloutAnimatorController.MakeUniqueLayerName("VRC3CVR_LocalOnlyContacts");
-        chilloutAnimatorController.AddLayer(new AnimatorControllerLayer
+        AddGeneratedLayer(new AnimatorControllerLayer
         {
             name = layerName,
             avatarMask = emptyMask,

--- a/Editor/VRC3CVRCore.cs
+++ b/Editor/VRC3CVRCore.cs
@@ -60,11 +60,8 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
     // This stores generated extra avatar masks based on the VRC hardcoded animator masks combined with individual layer masks.
     Dictionary<(AvatarMask, AvatarMask), AvatarMask> avatarMaskCombineCache = new Dictionary<(AvatarMask, AvatarMask), AvatarMask>();
 
-    // Layers this conversion generated (feed layers, contact proxy layers, etc.), keyed by the name
-    // they actually ended up with — MakeUniqueLayerName may suffix it. NOT inferred from the
-    // "VRC3CVR_" naming convention: an original VRC avatar layer can legally be named anything,
-    // including something that happens to start with that prefix, so name-sniffing would silently
-    // skip real avatar content. Populated only through AddGeneratedLayer so no call site can forget.
+    // Tracked rather than inferred from the "VRC3CVR_" prefix: an avatar's own layer can legally
+    // carry that name, and skipping it would silently drop real content from WalkParameterNames.
     HashSet<string> generatedLayerNames = new HashSet<string>();
 
     // This mask will mask all other layer masks from the gesture animator, and is derived from the
@@ -184,12 +181,7 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
             AdjustParameterNames();
             MakeGestureWeightFeedLayers();
             MakeVelocityMagnitudeFeedLayer();
-            // After AdjustParameterNames, like the feed layers above, so the names it rewrites are
-            // the final ones. Running after MakeVelocityMagnitudeFeedLayer does NOT require that
-            // layer's literal "VelocityX"/"VelocityZ" reads to survive by luck of ordering —
-            // WalkParameterNames skips every layer recorded in generatedLayerNames (see
-            // AddGeneratedLayer), so this pass structurally cannot see, let alone corrupt, a feed
-            // layer's own reads, regardless of what order Convert() calls things in.
+            // After AdjustParameterNames, like the feed layers above, so the names are final.
             RemapVelocityToAvatarLocal();
             MakeGameStateParameterStreams();
             InsertChilloutOverride();
@@ -1287,27 +1279,19 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
         return name;
     }
 
-    // Set while a targeted rename pass is running. The whole AdjustParameterNames* walker —
-    // transitions, driver tasks, blend tree axes, AAP curves, state time/speed/cycleOffset — is the
-    // only complete inventory of the places a parameter name can hide, so a second pass with a
-    // different mapping reuses it rather than growing a parallel walker that will drift.
+    // Overrides the rename rule for the duration of a WalkParameterNames pass.
     System.Func<string, string> parameterRenamer;
 
-    // Layers only, deliberately: AdjustParameterNamesOnAnimator also renames the DECLARATIONS, and
-    // a targeted pass wants the references pointed elsewhere while the original parameter stays
-    // declared — VelocityX is still the client-fed input the derived value is computed from.
+    // Rewrites parameter references with an arbitrary mapping, reusing the AdjustParameterNames*
+    // walker because that is the only complete inventory of the places a name can hide.
     //
-    // Layers vrc3cvr itself generated are skipped, via generatedLayerNames rather than by sniffing
-    // the "VRC3CVR_" name prefix: an original VRC avatar layer can legally be named anything,
-    // including something that happens to start with that prefix, and skipping it on name alone
-    // would silently drop real avatar content from the walk. Generated layers' parameter references
-    // are exactly what their own generator chose on purpose (e.g. the magnitude layer's literal
-    // "VelocityX"/"VelocityZ" reads are deliberately world-space); a second, narrower rename pass
-    // has no business rewriting content this same Convert() call just produced, only content
-    // carried over from the original avatar. Without this, a targeted pass whose mapping happens to
-    // match a generated layer's own reads corrupts that layer — and can manufacture a false "this
-    // parameter is used" signal from its own output, independent of what order Convert() happens to
-    // call things in.
+    // Declarations are left alone: a targeted pass repoints references while the original parameter
+    // stays declared, since it is still the client-fed input its replacement is computed from.
+    //
+    // Generated layers are skipped because their references are what their own generator chose on
+    // purpose — the magnitude layer's world-space VelocityX/Z reads are deliberate — so a later,
+    // narrower pass that happens to match them would corrupt that layer and manufacture a false
+    // "this parameter is used" signal from its own output.
     void WalkParameterNames(System.Func<string, string> renamer)
     {
         parameterRenamer = renamer;
@@ -1328,10 +1312,7 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
         }
     }
 
-    // The single choke point every generated layer must go through, so generatedLayerNames (see
-    // WalkParameterNames) can never miss one — a call site that used chilloutAnimatorController
-    // .AddLayer directly would silently reintroduce the corruption this exists to prevent. Keyed on
-    // layer.name as actually assigned, since MakeUniqueLayerName may have suffixed it.
+    // The one way to add a layer, so nothing can be left out of generatedLayerNames by forgetting.
     void AddGeneratedLayer(AnimatorControllerLayer layer)
     {
         chilloutAnimatorController.AddLayer(layer);
@@ -3886,8 +3867,7 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
         {
             return;
         }
-        // declared here, not by the feed layer: the feed layer's own guard is "does anything read
-        // the derived parameters", and pointing the references at them is what makes that true
+        // declared here rather than by the feed layer, whose guard is "does anything read these"
         var parameters = chilloutAnimatorController.parameters;
         foreach (var derived in new[] { localX, localZ })
         {
@@ -3906,17 +3886,14 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
     }
 
     // ChilloutVR reports VelocityX/Y/Z in WORLD space (measured in game), while every VRChat layer
-    // was authored against an avatar-LOCAL VelocityX/VelocityZ. The reconstruction cannot be
-    // written back into VelocityX/Z — the client rewrites those every frame — so it lands in
-    // derived parameters and RemapVelocityToAvatarLocal points the converted layers at them.
+    // was authored against an avatar-LOCAL VelocityX/VelocityZ. The reconstruction cannot be written
+    // back into VelocityX/Z — the client rewrites those every frame — so it lands in derived
+    // parameters that RemapVelocityToAvatarLocal points the converted layers at.
     //
-    // MovementX/Y give the direction: they are player-local by construction, +X right and +Y
-    // forward, matching VRChat's VelocityX/VelocityZ axes. They are NOT a unit vector — 0.5 is the
-    // walk ring and 1.0 the run ring — so only their direction is used and the magnitude comes from
-    // the world velocity, which is frame-independent. Verified in game at 0.000 m/s mean error.
-    //
-    // Both inputs are ChilloutVR synced core parameters, so this costs no sync bits and holds on
-    // remote copies as well as the wearer's.
+    // MovementX/Y supply the direction: player-local by construction, +X right and +Y forward, the
+    // same axes VRChat means. Only their direction, though — 0.5 is the walk ring and 1.0 the run
+    // ring, so the magnitude has to come from the world velocity instead. Both are ChilloutVR
+    // synced core parameters, so this costs no sync bits and holds on remote copies too.
     void MakeLocomotionVelocityFeedLayer()
     {
         var parameters = chilloutAnimatorController.parameters;
@@ -3924,7 +3901,6 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
         var localZ = NonSyncParameterName("VelocityZLocal");
         if (!parameters.Any(p => p.name == localX) && !parameters.Any(p => p.name == localZ))
         {
-            // no converted layer asked for an avatar-local velocity
             return;
         }
         foreach (var inputName in new[] { "VelocityX", "VelocityZ", "MovementX", "MovementY" })
@@ -3993,12 +3969,11 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
                     localOnly = false,
                     EnterTasks = new List<AnimatorDriverTask>
                     {
-                        // ground speed; the Y axis is not part of a locomotion tree's space
+                        // ground speed: a locomotion tree's space has no vertical axis
                         Task(AnimatorDriverTask.Operator.Multiplication, scratch, "VelocityX", "VelocityX"),
                         Task(AnimatorDriverTask.Operator.Multiplication, localX, "VelocityZ", "VelocityZ"),
                         Task(AnimatorDriverTask.Operator.Addition, scratch, scratch, localX),
                         Task(AnimatorDriverTask.Operator.Power, scratch, scratch, null, 0.5f),
-                        // the walk/run ring
                         Task(AnimatorDriverTask.Operator.Multiplication, localZ, "MovementX", "MovementX"),
                         Task(AnimatorDriverTask.Operator.Multiplication, localX, "MovementY", "MovementY"),
                         Task(AnimatorDriverTask.Operator.Addition, localZ, localZ, localX),

--- a/Editor/VRC3CVRCore.cs
+++ b/Editor/VRC3CVRCore.cs
@@ -176,9 +176,11 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
             AdjustParameterNames();
             MakeGestureWeightFeedLayers();
             MakeVelocityMagnitudeFeedLayer();
-            // after AdjustParameterNames, like the feed layers above, so the names it rewrites are
-            // the final ones — and after MakeVelocityMagnitudeFeedLayer, whose own VelocityX/Z reads
-            // are the world-space ones it wants
+            // After AdjustParameterNames, like the feed layers above, so the names it rewrites are
+            // the final ones. Running after MakeVelocityMagnitudeFeedLayer does NOT require that
+            // layer's literal "VelocityX"/"VelocityZ" reads to survive by luck of ordering —
+            // WalkParameterNames skips vrc3cvr's own "VRC3CVR_"-prefixed layers outright, so this
+            // pass structurally cannot see (and previously did corrupt) a feed layer's own reads.
             RemapVelocityToAvatarLocal();
             MakeGameStateParameterStreams();
             InsertChilloutOverride();
@@ -1284,6 +1286,17 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
     // Layers only, deliberately: AdjustParameterNamesOnAnimator also renames the DECLARATIONS, and
     // a targeted pass wants the references pointed elsewhere while the original parameter stays
     // declared — VelocityX is still the client-fed input the derived value is computed from.
+    //
+    // Layers vrc3cvr itself generated are skipped, identified by the "VRC3CVR_" prefix every
+    // feed/proxy layer this codebase creates uses (MakeVelocityMagnitudeFeedLayer,
+    // MakeGestureWeightFeedLayers, MakeLocomotionVelocityFeedLayer, the contact proxy/local-only
+    // layers — see the AddLayer call sites). Their parameter references are exactly what their own
+    // generator chose on purpose (e.g. the magnitude layer's literal "VelocityX"/"VelocityZ" reads
+    // are deliberately world-space); a second, narrower rename pass has no business rewriting
+    // content this same Convert() call just produced, only content carried over from the original
+    // avatar. Without this, a targeted pass whose mapping happens to match a generated layer's own
+    // reads corrupts that layer — and can manufacture a false "this parameter is used" signal from
+    // its own output, independent of what order Convert() happens to call things in.
     void WalkParameterNames(System.Func<string, string> renamer)
     {
         parameterRenamer = renamer;
@@ -1291,6 +1304,10 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
         {
             foreach (var layer in chilloutAnimatorController.layers)
             {
+                if (layer.name.StartsWith("VRC3CVR_"))
+                {
+                    continue;
+                }
                 AdjustParameterNamesOnStateMachine(layer.stateMachine);
             }
         }

--- a/Tests/Editor/VRC3CVRCvrProbeAvatar.cs
+++ b/Tests/Editor/VRC3CVRCvrProbeAvatar.cs
@@ -1,0 +1,408 @@
+#if CVR_CCK_EXISTS
+using System.Collections.Generic;
+using ABI.CCK.Components;
+using ABI.CCK.Scripts;
+using UnityEditor;
+using UnityEditor.Animations;
+using UnityEngine;
+
+// Generates a ChilloutVR-NATIVE probe avatar: built with the CCK directly, uploaded as-is, never
+// run through the conversion.
+//
+// Why it does not go through vrc3cvr: everything it measures is a question about what the
+// ChilloutVR client hands an animator — the space and unit of the core velocity parameters, what
+// each CVRParameterStream source actually reports, whether an AnimatorDriver can reconstruct an
+// avatar-local velocity from them. None of that is a question about the conversion, so putting the
+// conversion in the path would only add a second thing that can be wrong.
+//
+// It is also deliberately NOT a probe assembled at runtime by the verification mod. A component a
+// mod adds to a worn avatar is not guaranteed to behave like one that shipped with the avatar: the
+// client may collect and initialise streams at avatar load, and may cache the Rigidbody or
+// transform an entry resolves against. The only reading that settles a design question is the one
+// taken through the real mechanism, so the probe ships inside the uploaded avatar.
+//
+// Upload it once and reuse the same content id, like the other verification avatars, and record
+// the id as "probe=<id>" in VerificationAvatarIds.txt.
+public static class VRC3CVRCvrProbeAvatar
+{
+    public const string DefaultAssetFolder = "Assets/VRC3CVR_CvrProbeAvatar";
+
+    // Fed by the client to any avatar that declares them (ABI.CCK.Scripts.CVRCommon).
+    public const string MovementX = "MovementX";
+    public const string MovementY = "MovementY";
+    public const string VelocityX = "VelocityX";
+    public const string VelocityY = "VelocityY";
+    public const string VelocityZ = "VelocityZ";
+
+    // Written by the parameter stream; the names are the probe's readout.
+    public const string StreamRigidBodySpeed = "PrbRbSpeed";
+    public const string StreamRigidBodyVelX = "PrbRbVelX";
+    public const string StreamRigidBodyVelZ = "PrbRbVelZ";
+    public const string StreamRigidBodyLocalVelX = "PrbRbLocalVelX";
+    public const string StreamRigidBodyLocalVelZ = "PrbRbLocalVelZ";
+    public const string StreamWorldYaw = "PrbWorldYaw";
+    public const string StreamInputMoveX = "PrbInputMoveX";
+    public const string StreamInputMoveY = "PrbInputMoveY";
+    public const string StreamUpright = "PrbUpright";
+
+    // Written by the AnimatorDriver layer — the conversion under test.
+    public const string DerivedSpeed = "PrbSpeed";
+    public const string DerivedMoveMagnitude = "PrbMoveMag";
+    public const string DerivedLocalVelX = "PrbReconX";
+    public const string DerivedLocalVelZ = "PrbReconZ";
+
+    [MenuItem("Tools/VRC3CVR/Create CVR Probe Avatar")]
+    public static void CreateFromMenu()
+    {
+        var avatar = Generate(DefaultAssetFolder);
+        Selection.activeGameObject = avatar.gameObject;
+    }
+
+    public static CVRAvatar Generate(string assetFolder)
+    {
+        if (!AssetDatabase.IsValidFolder(assetFolder))
+        {
+            var parent = System.IO.Path.GetDirectoryName(assetFolder).Replace('\\', '/');
+            AssetDatabase.CreateFolder(parent, System.IO.Path.GetFileName(assetFolder));
+        }
+
+        var root = new GameObject("VRC3CVR CVR Probe Avatar");
+        var bones = BuildRig(root);
+        var animator = root.AddComponent<Animator>();
+        animator.avatar = BuildHumanAvatar(root, bones, assetFolder);
+
+        var controller = BuildController(assetFolder);
+
+        var cvrAvatar = root.AddComponent<CVRAvatar>();
+        cvrAvatar.viewPosition = new Vector3(0f, 1.45f, 0.1f);
+        cvrAvatar.voicePosition = new Vector3(0f, 1.45f, 0.1f);
+        cvrAvatar.avatarUsesAdvancedSettings = true;
+        cvrAvatar.avatarSettings = new CVRAdvancedAvatarSettings
+        {
+            initialized = true,
+            settings = new List<CVRAdvancedSettingsEntry>(),
+            baseController = controller,
+        };
+        // The override controller is the one the client actually runs — baseController alone is
+        // "part of autogen" and leaves the worn avatar on the CCK's stock animator, which is
+        // exactly what the first upload of this probe did: it came back with the stock 13
+        // parameters and none of the probe's own.
+        var overrideController = new AnimatorOverrideController(controller)
+        {
+            name = "CvrProbe Overrides",
+        };
+        AssetDatabase.CreateAsset(overrideController, assetFolder + "/CvrProbe.overrideController");
+        cvrAvatar.overrides = overrideController;
+
+        BuildParameterStream(root);
+
+        AssetDatabase.SaveAssets();
+        return cvrAvatar;
+    }
+
+    // ---- parameter stream ----
+
+    // On the ROOT deliberately. The Transform sources read "the transform where the Parameter
+    // Stream component is placed", and the Rigidbody sources resolve to "the Rigidbody on the same
+    // or a parent GameObject" — which, on a worn avatar, means walking up into the player rig. Both
+    // of those are exactly the resolutions a conversion would have to rely on.
+    static void BuildParameterStream(GameObject root)
+    {
+        var stream = root.AddComponent<CVRParameterStream>();
+        stream.referenceType = CVRParameterStream.ReferenceType.Avatar;
+        stream.entries = new List<CVRParameterStreamEntry>();
+
+        void Entry(CVRParameterStreamEntry.Type type, string parameterName)
+        {
+            stream.entries.Add(new CVRParameterStreamEntry
+            {
+                type = type,
+                targetType = CVRParameterStreamEntry.TargetType.AvatarAnimator,
+                applicationType = CVRParameterStreamEntry.ApplicationType.Override,
+                parameterName = parameterName,
+            });
+        }
+
+        // Does a Rigidbody source resolve to anything on a worn avatar, and does its LOCAL variant
+        // carry an avatar-local velocity? A mod-side read of Rigidbody.velocity on the nearest
+        // ancestor came back zero, which suggests the client's character controller moves a
+        // kinematic body — but that is a reading of Unity's property, not of what this source
+        // reports, so it settles nothing on its own.
+        Entry(CVRParameterStreamEntry.Type.RigidBodySpeed, StreamRigidBodySpeed);
+        Entry(CVRParameterStreamEntry.Type.RigidBodyVelocityX, StreamRigidBodyVelX);
+        Entry(CVRParameterStreamEntry.Type.RigidBodyVelocityZ, StreamRigidBodyVelZ);
+        Entry(CVRParameterStreamEntry.Type.RigidBodyLocalVelocityX, StreamRigidBodyLocalVelX);
+        Entry(CVRParameterStreamEntry.Type.RigidBodyLocalVelocityZ, StreamRigidBodyLocalVelZ);
+
+        // The fallback route if no Rigidbody source works: yaw plus trigonometry. The CCK
+        // documents the value range of the Transform rotation sources as unknown, so the range and
+        // the sign convention have to be measured before anything can be built on them.
+        Entry(CVRParameterStreamEntry.Type.TransformGlobalRotationY, StreamWorldYaw);
+
+        // Movement INPUT is player-local by construction. If it matches the MovementX/MovementY
+        // core parameters, the conversion needs neither a Rigidbody source nor trigonometry.
+        Entry(CVRParameterStreamEntry.Type.InputMovementX, StreamInputMoveX);
+        Entry(CVRParameterStreamEntry.Type.InputMovementY, StreamInputMoveY);
+
+        // Already measured through the conversion (standing 0.968 / crouching 0.491 / prone 0.092);
+        // carried here to confirm the same reading with no conversion in the path.
+        Entry(CVRParameterStreamEntry.Type.AvatarUpright, StreamUpright);
+    }
+
+    // ---- animator ----
+
+    static AnimatorController BuildController(string assetFolder)
+    {
+        var controller = AnimatorController.CreateAnimatorControllerAtPath(assetFolder + "/CvrProbe.controller");
+        // Unity gives a fresh controller one layer; the driver lives there.
+        foreach (var name in new[]
+        {
+            MovementX, MovementY, VelocityX, VelocityY, VelocityZ,
+            StreamRigidBodySpeed, StreamRigidBodyVelX, StreamRigidBodyVelZ,
+            StreamRigidBodyLocalVelX, StreamRigidBodyLocalVelZ,
+            StreamWorldYaw, StreamInputMoveX, StreamInputMoveY, StreamUpright,
+            DerivedSpeed, DerivedMoveMagnitude, DerivedLocalVelX, DerivedLocalVelZ,
+        })
+        {
+            controller.AddParameter(name, AnimatorControllerParameterType.Float);
+        }
+
+        AddDriverLayer(controller);
+        EditorUtility.SetDirty(controller);
+        return controller;
+    }
+
+    // The conversion under test, in the form it would take in the converter.
+    //
+    // ChilloutVR reports VelocityX/Z in WORLD space (measured), while VRChat's locomotion blend
+    // trees are built in avatar-LOCAL space. MovementX/Y point the right way — measured at
+    // (0, +0.5) walking forward, (0, -0.5) backward and (+0.5, 0) strafing right, so +Y is forward
+    // and +X is right, exactly VRChat's VelocityZ / VelocityX axes — but they are NOT a unit
+    // vector: 0.5 is the walk ring and 1.0 the run ring, matching the rings in the CCK's own
+    // locomotion trees. Multiplying them by the speed would therefore halve a walk.
+    //
+    // So the direction comes from MovementX/Y and the magnitude from the world velocity, which is
+    // frame-independent:
+    //
+    //     scale = |world ground velocity| / |(MovementX, MovementY)|
+    //     local velocity = (MovementX, MovementY) * scale
+    //
+    // The epsilon on the divisor is what keeps standing still well defined: at rest the numerator
+    // is ~0, so the scale collapses to ~0 rather than dividing by zero.
+    static void AddDriverLayer(AnimatorController controller)
+    {
+        AnimatorDriverTask Task(AnimatorDriverTask.Operator op, string targetName, string aName, string bName, float bValue = 0f)
+        {
+            return new AnimatorDriverTask
+            {
+                op = op,
+                targetName = targetName,
+                targetType = AnimatorDriverTask.ParameterType.Float,
+                aType = AnimatorDriverTask.SourceType.Parameter,
+                aParamType = AnimatorDriverTask.ParameterType.Float,
+                aName = aName,
+                bType = bName == null ? AnimatorDriverTask.SourceType.Static : AnimatorDriverTask.SourceType.Parameter,
+                bParamType = AnimatorDriverTask.ParameterType.Float,
+                bName = bName ?? "",
+                bValue = bValue,
+            };
+        }
+
+        // A short clip gives the state a length, so the self transition re-enters it — and reruns
+        // the driver — every tick. The animated property is undeclared and does nothing.
+        var tickClip = new AnimationClip { name = "VRC3CVR_ProbeTick" };
+        tickClip.SetCurve("", typeof(Animator), "VRC3CVR_ProbeTick", AnimationCurve.Constant(0f, 1f / 60f, 0f));
+        AssetDatabase.AddObjectToAsset(tickClip, controller);
+
+        var state = new AnimatorState
+        {
+            hideFlags = HideFlags.HideInHierarchy,
+            name = "Recompute",
+            writeDefaultValues = false,
+            motion = tickClip,
+            behaviours = new StateMachineBehaviour[]
+            {
+                new AnimatorDriver
+                {
+                    hideFlags = HideFlags.HideInHierarchy,
+                    // remote copies run this too, so the reconstruction has to hold there as well
+                    localOnly = false,
+                    // Tasks run in order and may read and write the same parameter, so the two
+                    // outputs double as scratch space until the step that fills them.
+                    EnterTasks = new List<AnimatorDriverTask>
+                    {
+                        // ground speed: the Y axis is not part of a locomotion tree's space
+                        Task(AnimatorDriverTask.Operator.Multiplication, DerivedSpeed, VelocityX, VelocityX),
+                        Task(AnimatorDriverTask.Operator.Multiplication, DerivedLocalVelZ, VelocityZ, VelocityZ),
+                        Task(AnimatorDriverTask.Operator.Addition, DerivedSpeed, DerivedSpeed, DerivedLocalVelZ),
+                        Task(AnimatorDriverTask.Operator.Power, DerivedSpeed, DerivedSpeed, null, 0.5f),
+                        // |(MovementX, MovementY)| — the walk/run ring, reported for its own sake
+                        Task(AnimatorDriverTask.Operator.Multiplication, DerivedMoveMagnitude, MovementX, MovementX),
+                        Task(AnimatorDriverTask.Operator.Multiplication, DerivedLocalVelZ, MovementY, MovementY),
+                        Task(AnimatorDriverTask.Operator.Addition, DerivedMoveMagnitude, DerivedMoveMagnitude, DerivedLocalVelZ),
+                        Task(AnimatorDriverTask.Operator.Power, DerivedMoveMagnitude, DerivedMoveMagnitude, null, 0.5f),
+                        // scale = speed / (ring + epsilon), parked in ReconX until it is consumed
+                        Task(AnimatorDriverTask.Operator.Addition, DerivedLocalVelX, DerivedMoveMagnitude, null, 0.0001f),
+                        Task(AnimatorDriverTask.Operator.Division, DerivedLocalVelX, DerivedSpeed, DerivedLocalVelX),
+                        // Z first: filling X overwrites the scale both of them need
+                        Task(AnimatorDriverTask.Operator.Multiplication, DerivedLocalVelZ, MovementY, DerivedLocalVelX),
+                        Task(AnimatorDriverTask.Operator.Multiplication, DerivedLocalVelX, MovementX, DerivedLocalVelX),
+                    },
+                },
+            },
+        };
+        state.transitions = new AnimatorStateTransition[]
+        {
+            new AnimatorStateTransition
+            {
+                hideFlags = HideFlags.HideInHierarchy,
+                hasExitTime = true,
+                exitTime = 1f,
+                hasFixedDuration = true,
+                duration = 0f,
+                offset = 0f,
+                destinationState = state,
+            },
+        };
+        AssetDatabase.AddObjectToAsset(state, controller);
+        foreach (var behaviour in state.behaviours)
+        {
+            AssetDatabase.AddObjectToAsset(behaviour, controller);
+        }
+        foreach (var transition in state.transitions)
+        {
+            AssetDatabase.AddObjectToAsset(transition, controller);
+        }
+
+        var stateMachine = controller.layers[0].stateMachine;
+        stateMachine.states = new ChildAnimatorState[]
+        {
+            new ChildAnimatorState { state = state, position = new Vector3(0f, 0f) },
+        };
+        stateMachine.defaultState = state;
+    }
+
+    // ---- rig ----
+
+    // A copy of the primitive humanoid the VRChat-side fixture builds, rather than a reference to
+    // it: this file must compile with only the CCK present, and that one is behind the VRChat SDK
+    // guard. The rig is incidental here — it exists so ChilloutVR treats this as a humanoid avatar
+    // with locomotion, which is the condition the measured parameters are fed under.
+    class Bones
+    {
+        public Transform hips, spine, head;
+        public Transform leftUpperLeg, leftLowerLeg, leftFoot, rightUpperLeg, rightLowerLeg, rightFoot;
+        public Transform leftUpperArm, leftLowerArm, leftHand, rightUpperArm, rightLowerArm, rightHand;
+        public Transform armature;
+    }
+
+    static Bones BuildRig(GameObject root)
+    {
+        Transform Bone(string name, Transform parent, Vector3 worldPosition, float visualSize = 0.06f)
+        {
+            var bone = new GameObject(name).transform;
+            bone.SetParent(parent, false);
+            bone.position = worldPosition;
+            if (visualSize > 0f)
+            {
+                var visual = GameObject.CreatePrimitive(PrimitiveType.Cube);
+                visual.name = name + "_Visual";
+                Object.DestroyImmediate(visual.GetComponent<Collider>());
+                visual.transform.SetParent(bone, false);
+                visual.transform.localScale = Vector3.one * visualSize;
+            }
+            return bone;
+        }
+
+        var bones = new Bones();
+        bones.armature = Bone("Armature", root.transform, Vector3.zero, 0f);
+        bones.hips = Bone("Hips", bones.armature, new Vector3(0f, 0.9f, 0f), 0.12f);
+        bones.spine = Bone("Spine", bones.hips, new Vector3(0f, 1.1f, 0f), 0.1f);
+        bones.head = Bone("Head", bones.spine, new Vector3(0f, 1.45f, 0f), 0.14f);
+        bones.leftUpperLeg = Bone("LeftUpperLeg", bones.hips, new Vector3(0.1f, 0.85f, 0f));
+        bones.leftLowerLeg = Bone("LeftLowerLeg", bones.leftUpperLeg, new Vector3(0.1f, 0.45f, 0f));
+        bones.leftFoot = Bone("LeftFoot", bones.leftLowerLeg, new Vector3(0.1f, 0.05f, 0f));
+        bones.rightUpperLeg = Bone("RightUpperLeg", bones.hips, new Vector3(-0.1f, 0.85f, 0f));
+        bones.rightLowerLeg = Bone("RightLowerLeg", bones.rightUpperLeg, new Vector3(-0.1f, 0.45f, 0f));
+        bones.rightFoot = Bone("RightFoot", bones.rightLowerLeg, new Vector3(-0.1f, 0.05f, 0f));
+        bones.leftUpperArm = Bone("LeftUpperArm", bones.spine, new Vector3(0.2f, 1.35f, 0f));
+        bones.leftLowerArm = Bone("LeftLowerArm", bones.leftUpperArm, new Vector3(0.45f, 1.35f, 0f));
+        bones.leftHand = Bone("LeftHand", bones.leftLowerArm, new Vector3(0.7f, 1.35f, 0f));
+        bones.rightUpperArm = Bone("RightUpperArm", bones.spine, new Vector3(-0.2f, 1.35f, 0f));
+        bones.rightLowerArm = Bone("RightLowerArm", bones.rightUpperArm, new Vector3(-0.45f, 1.35f, 0f));
+        bones.rightHand = Bone("RightHand", bones.rightLowerArm, new Vector3(-0.7f, 1.35f, 0f));
+        return bones;
+    }
+
+    static Avatar BuildHumanAvatar(GameObject root, Bones bones, string assetFolder)
+    {
+        var humanBones = new List<HumanBone>();
+        void Map(string humanName, Transform bone)
+        {
+            humanBones.Add(new HumanBone { humanName = humanName, boneName = bone.name, limit = new HumanLimit { useDefaultValues = true } });
+        }
+        Map("Hips", bones.hips);
+        Map("Spine", bones.spine);
+        Map("Head", bones.head);
+        Map("LeftUpperLeg", bones.leftUpperLeg);
+        Map("LeftLowerLeg", bones.leftLowerLeg);
+        Map("LeftFoot", bones.leftFoot);
+        Map("RightUpperLeg", bones.rightUpperLeg);
+        Map("RightLowerLeg", bones.rightLowerLeg);
+        Map("RightFoot", bones.rightFoot);
+        Map("LeftUpperArm", bones.leftUpperArm);
+        Map("LeftLowerArm", bones.leftLowerArm);
+        Map("LeftHand", bones.leftHand);
+        Map("RightUpperArm", bones.rightUpperArm);
+        Map("RightLowerArm", bones.rightLowerArm);
+        Map("RightHand", bones.rightHand);
+
+        var skeleton = new List<SkeletonBone> { SkeletonOf(root.transform) };
+        void AddSkeleton(Transform bone)
+        {
+            skeleton.Add(SkeletonOf(bone));
+            foreach (Transform child in bone)
+            {
+                if (!child.name.EndsWith("_Visual"))
+                {
+                    AddSkeleton(child);
+                }
+            }
+        }
+        AddSkeleton(bones.armature);
+
+        var description = new HumanDescription
+        {
+            human = humanBones.ToArray(),
+            skeleton = skeleton.ToArray(),
+            upperArmTwist = 0.5f,
+            lowerArmTwist = 0.5f,
+            upperLegTwist = 0.5f,
+            lowerLegTwist = 0.5f,
+            armStretch = 0.05f,
+            legStretch = 0.05f,
+            feetSpacing = 0f,
+            hasTranslationDoF = false,
+        };
+        var avatar = AvatarBuilder.BuildHumanAvatar(root, description);
+        if (!avatar.isValid)
+        {
+            throw new System.Exception("Generated human avatar is not valid");
+        }
+        avatar.name = "VRC3CVRCvrProbeAvatar";
+        AssetDatabase.CreateAsset(avatar, assetFolder + "/CvrProbeAvatar.asset");
+        return avatar;
+    }
+
+    static SkeletonBone SkeletonOf(Transform transform)
+    {
+        return new SkeletonBone
+        {
+            name = transform.name,
+            position = transform.localPosition,
+            rotation = transform.localRotation,
+            scale = transform.localScale,
+        };
+    }
+}
+#endif

--- a/Tests/Editor/VRC3CVRCvrProbeAvatar.cs.meta
+++ b/Tests/Editor/VRC3CVRCvrProbeAvatar.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ef7c1c009e1e9a046bba128383b294f8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/VRC3CVRVelocityCompatTests.cs
+++ b/Tests/Editor/VRC3CVRVelocityCompatTests.cs
@@ -49,5 +49,69 @@ public class VRC3CVRVelocityCompatTests
 
         Object.DestroyImmediate(controller);
     }
+
+    [Test]
+    public void LocomotionVelocityLayer_DerivesLocalVelocityFromMovementAndSpeed()
+    {
+        var controller = new AnimatorController { name = "velocityLocalTest" };
+        controller.AddParameter("#VelocityXLocal", AnimatorControllerParameterType.Float);
+        controller.AddParameter("#VelocityZLocal", AnimatorControllerParameterType.Float);
+        var core = MakeCore(controller);
+
+        typeof(VRC3CVRCore).GetMethod("MakeLocomotionVelocityFeedLayer", Flags).Invoke(core, null);
+
+        var names = controller.parameters.Select(p => p.name).ToArray();
+        CollectionAssert.Contains(names, "VelocityX");
+        CollectionAssert.Contains(names, "VelocityZ");
+        CollectionAssert.Contains(names, "MovementX");
+        CollectionAssert.Contains(names, "MovementY");
+        CollectionAssert.Contains(names, "#VelocityLocalCalc");
+
+        Assert.AreEqual(1, controller.layers.Length);
+        var layer = controller.layers[0];
+        Assert.AreEqual(1f, layer.defaultWeight);
+        var state = layer.stateMachine.states.Single().state;
+        Assert.AreEqual(state, state.transitions.Single().destinationState);
+        var driver = (ABI.CCK.Components.AnimatorDriver)state.behaviours.Single();
+        Assert.IsFalse(driver.localOnly, "リモートでも MovementX/Y と VelocityX/Z は供給されるので走らせる");
+        Assert.AreEqual(
+            new[]
+            {
+                // 地上速度 -> #VelocityLocalCalc
+                "Multiplication #VelocityLocalCalc = VelocityX, VelocityX",
+                "Multiplication #VelocityXLocal = VelocityZ, VelocityZ",
+                "Addition #VelocityLocalCalc = #VelocityLocalCalc, #VelocityXLocal",
+                "Power #VelocityLocalCalc = #VelocityLocalCalc, 0.5",
+                // 歩き 0.5 / 走り 1.0 のリング -> #VelocityZLocal
+                "Multiplication #VelocityZLocal = MovementX, MovementX",
+                "Multiplication #VelocityXLocal = MovementY, MovementY",
+                "Addition #VelocityZLocal = #VelocityZLocal, #VelocityXLocal",
+                "Power #VelocityZLocal = #VelocityZLocal, 0.5",
+                // scale = speed / (ring + eps)
+                "Addition #VelocityXLocal = #VelocityZLocal, 0.0001",
+                "Division #VelocityXLocal = #VelocityLocalCalc, #VelocityXLocal",
+                // Z が先。X を埋めると両者が使う scale が消える
+                "Multiplication #VelocityZLocal = MovementY, #VelocityXLocal",
+                "Multiplication #VelocityXLocal = MovementX, #VelocityXLocal",
+            },
+            driver.EnterTasks.Select(t =>
+                t.op + " " + t.targetName + " = " + t.aName + ", " +
+                (t.bType == ABI.CCK.Components.AnimatorDriverTask.SourceType.Static ? t.bValue.ToString("0.####") : t.bName)
+            ).ToArray());
+
+        Object.DestroyImmediate(controller);
+    }
+
+    [Test]
+    public void LocomotionVelocityLayer_SkippedWhenParametersUnused()
+    {
+        var controller = new AnimatorController { name = "velocityLocalTest" };
+        var core = MakeCore(controller);
+
+        typeof(VRC3CVRCore).GetMethod("MakeLocomotionVelocityFeedLayer", Flags).Invoke(core, null);
+
+        Assert.AreEqual(0, controller.layers.Length);
+        Object.DestroyImmediate(controller);
+    }
 }
 #endif

--- a/Tests/Editor/VRC3CVRVelocityCompatTests.cs
+++ b/Tests/Editor/VRC3CVRVelocityCompatTests.cs
@@ -113,5 +113,60 @@ public class VRC3CVRVelocityCompatTests
         Assert.AreEqual(0, controller.layers.Length);
         Object.DestroyImmediate(controller);
     }
+
+    [Test]
+    public void RemapVelocity_PointsConvertedLayersAtTheDerivedParameters()
+    {
+        var controller = new AnimatorController { name = "remapTest" };
+        controller.AddParameter("VelocityX", AnimatorControllerParameterType.Float);
+        controller.AddParameter("VelocityY", AnimatorControllerParameterType.Float);
+        controller.AddParameter("VelocityZ", AnimatorControllerParameterType.Float);
+        controller.AddLayer("L");
+        var machine = controller.layers[0].stateMachine;
+        var state = machine.AddState("S");
+        state.motion = new BlendTree
+        {
+            blendType = BlendTreeType.SimpleDirectional2D,
+            blendParameter = "VelocityX",
+            blendParameterY = "VelocityZ",
+        };
+        var core = MakeCore(controller);
+
+        typeof(VRC3CVRCore).GetMethod("RemapVelocityToAvatarLocal", Flags).Invoke(core, null);
+
+        var tree = (BlendTree)controller.layers[0].stateMachine.states[0].state.motion;
+        Assert.AreEqual("#VelocityXLocal", tree.blendParameter);
+        Assert.AreEqual("#VelocityZLocal", tree.blendParameterY);
+        // the derived parameters exist and the feed layer was added
+        var names = controller.parameters.Select(p => p.name).ToArray();
+        CollectionAssert.Contains(names, "#VelocityXLocal");
+        CollectionAssert.Contains(names, "#VelocityZLocal");
+        Assert.AreEqual(1, controller.layers.Count(l => l.name.StartsWith("VRC3CVR_LocomotionVelocity")));
+
+        Object.DestroyImmediate(controller);
+    }
+
+    [Test]
+    public void RemapVelocity_LeavesVerticalVelocityAlone()
+    {
+        var controller = new AnimatorController { name = "remapTest" };
+        controller.AddParameter("VelocityY", AnimatorControllerParameterType.Float);
+        controller.AddLayer("L");
+        var machine = controller.layers[0].stateMachine;
+        var state = machine.AddState("S");
+        var transition = machine.AddAnyStateTransition(state);
+        transition.AddCondition(AnimatorConditionMode.Less, -0.5f, "VelocityY");
+        var core = MakeCore(controller);
+
+        typeof(VRC3CVRCore).GetMethod("RemapVelocityToAvatarLocal", Flags).Invoke(core, null);
+
+        // a yaw-only rotation leaves the vertical axis identical in both spaces
+        Assert.AreEqual("VelocityY",
+            controller.layers[0].stateMachine.anyStateTransitions[0].conditions[0].parameter);
+        Assert.AreEqual(0, controller.layers.Count(l => l.name.StartsWith("VRC3CVR_LocomotionVelocity")),
+            "VelocityX/Z を誰も読んでいないので導出層は要らない");
+
+        Object.DestroyImmediate(controller);
+    }
 }
 #endif

--- a/Tests/Editor/VRC3CVRVelocityCompatTests.cs
+++ b/Tests/Editor/VRC3CVRVelocityCompatTests.cs
@@ -200,5 +200,31 @@ public class VRC3CVRVelocityCompatTests
 
         Object.DestroyImmediate(controller);
     }
+
+    [Test]
+    public void RemapVelocity_RewritesASourceLayerWhoseNameCollidesWithTheGeneratedPrefix()
+    {
+        var controller = new AnimatorController { name = "collisionTest" };
+        controller.AddParameter("VelocityX", AnimatorControllerParameterType.Float);
+        controller.AddParameter("VelocityZ", AnimatorControllerParameterType.Float);
+        // An original VRC avatar layer can legally be named anything in Unity's Animator window,
+        // including something that collides with vrc3cvr's own "VRC3CVR_" generated-layer naming
+        // convention. It was never routed through AddGeneratedLayer, so it must still be walked.
+        controller.AddLayer("VRC3CVR_MyCoolLayer");
+        var machine = controller.layers[0].stateMachine;
+        var state = machine.AddState("S");
+        var transition = machine.AddAnyStateTransition(state);
+        transition.AddCondition(AnimatorConditionMode.Greater, 0.5f, "VelocityX");
+        var core = MakeCore(controller);
+
+        typeof(VRC3CVRCore).GetMethod("RemapVelocityToAvatarLocal", Flags).Invoke(core, null);
+
+        Assert.AreEqual("#VelocityXLocal",
+            controller.layers[0].stateMachine.anyStateTransitions[0].conditions[0].parameter,
+            "生成レイヤーの命名規則と偶然衝突しただけの元アバターレイヤーも書き換え対象");
+        Assert.AreEqual(1, controller.layers.Count(l => l.name.StartsWith("VRC3CVR_LocomotionVelocity")));
+
+        Object.DestroyImmediate(controller);
+    }
 }
 #endif

--- a/Tests/Editor/VRC3CVRVelocityCompatTests.cs
+++ b/Tests/Editor/VRC3CVRVelocityCompatTests.cs
@@ -1,0 +1,53 @@
+#if VRC_SDK_VRCSDK3 && CVR_CCK_EXISTS
+using System.Linq;
+using System.Reflection;
+using NUnit.Framework;
+using UnityEditor.Animations;
+using UnityEngine;
+
+public class VRC3CVRVelocityCompatTests
+{
+    const BindingFlags Flags = BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public;
+
+    static VRC3CVRCore MakeCore(AnimatorController controller)
+    {
+        var core = new VRC3CVRCore();
+        typeof(VRC3CVRCore).GetField("chilloutAnimatorController", Flags).SetValue(core, controller);
+        return core;
+    }
+
+    [Test]
+    public void WalkParameterNames_RewritesTransitionConditionsAndBlendTreeAxes()
+    {
+        var controller = new AnimatorController { name = "walkTest" };
+        controller.AddParameter("VelocityX", AnimatorControllerParameterType.Float);
+        controller.AddParameter("VelocityZ", AnimatorControllerParameterType.Float);
+        controller.AddLayer("L");
+
+        var layers = controller.layers;
+        var machine = layers[0].stateMachine;
+        var tree = new BlendTree
+        {
+            blendType = BlendTreeType.SimpleDirectional2D,
+            blendParameter = "VelocityX",
+            blendParameterY = "VelocityZ",
+        };
+        var state = machine.AddState("S");
+        state.motion = tree;
+        var transition = machine.AddAnyStateTransition(state);
+        transition.AddCondition(AnimatorConditionMode.Greater, 0.5f, "VelocityX");
+
+        var core = MakeCore(controller);
+        typeof(VRC3CVRCore).GetMethod("WalkParameterNames", Flags)
+            .Invoke(core, new object[] { (System.Func<string, string>)(name => name == "VelocityX" ? "#LocalX" : name) });
+
+        var walked = controller.layers[0].stateMachine;
+        Assert.AreEqual("#LocalX", walked.anyStateTransitions[0].conditions[0].parameter);
+        var walkedTree = (BlendTree)walked.states[0].state.motion;
+        Assert.AreEqual("#LocalX", walkedTree.blendParameter);
+        Assert.AreEqual("VelocityZ", walkedTree.blendParameterY, "マッピングに無い名前は触らない");
+
+        Object.DestroyImmediate(controller);
+    }
+}
+#endif

--- a/Tests/Editor/VRC3CVRVelocityCompatTests.cs
+++ b/Tests/Editor/VRC3CVRVelocityCompatTests.cs
@@ -47,10 +47,8 @@ public class VRC3CVRVelocityCompatTests
         Assert.AreEqual("#LocalX", walkedTree.blendParameter);
         Assert.AreEqual("VelocityZ", walkedTree.blendParameterY, "マッピングに無い名前は触らない");
 
-        // WalkParameterNames must only redirect layer REFERENCES, never the parameter
-        // DECLARATIONS (VRC3CVRCore.cs:1296-1299) — VelocityX/VelocityZ are the client-fed inputs
-        // the feed layer's derived values are computed from, so losing the declaration here would
-        // silently break that feed layer.
+        // The declarations must survive: they are the client-fed inputs the derived values are
+        // computed from, so a walk that renamed them would silently break the feed layer.
         var declaredNames = controller.parameters.Select(p => p.name).ToArray();
         CollectionAssert.Contains(declaredNames, "VelocityX");
         CollectionAssert.Contains(declaredNames, "VelocityZ");
@@ -85,20 +83,20 @@ public class VRC3CVRVelocityCompatTests
         Assert.AreEqual(
             new[]
             {
-                // 地上速度 -> #VelocityLocalCalc
+                // ground speed
                 "Multiplication #VelocityLocalCalc = VelocityX, VelocityX",
                 "Multiplication #VelocityXLocal = VelocityZ, VelocityZ",
                 "Addition #VelocityLocalCalc = #VelocityLocalCalc, #VelocityXLocal",
                 "Power #VelocityLocalCalc = #VelocityLocalCalc, 0.5",
-                // 歩き 0.5 / 走り 1.0 のリング -> #VelocityZLocal
+                // the walk/run ring
                 "Multiplication #VelocityZLocal = MovementX, MovementX",
                 "Multiplication #VelocityXLocal = MovementY, MovementY",
                 "Addition #VelocityZLocal = #VelocityZLocal, #VelocityXLocal",
                 "Power #VelocityZLocal = #VelocityZLocal, 0.5",
-                // scale = speed / (ring + eps)
+                // scale
                 "Addition #VelocityXLocal = #VelocityZLocal, 0.0001",
                 "Division #VelocityXLocal = #VelocityLocalCalc, #VelocityXLocal",
-                // Z が先。X を埋めると両者が使う scale が消える
+                // Z first: filling X overwrites the scale both of them need
                 "Multiplication #VelocityZLocal = MovementY, #VelocityXLocal",
                 "Multiplication #VelocityXLocal = MovementX, #VelocityXLocal",
             },
@@ -145,7 +143,6 @@ public class VRC3CVRVelocityCompatTests
         var tree = (BlendTree)controller.layers[0].stateMachine.states[0].state.motion;
         Assert.AreEqual("#VelocityXLocal", tree.blendParameter);
         Assert.AreEqual("#VelocityZLocal", tree.blendParameterY);
-        // the derived parameters exist and the feed layer was added
         var names = controller.parameters.Select(p => p.name).ToArray();
         CollectionAssert.Contains(names, "#VelocityXLocal");
         CollectionAssert.Contains(names, "#VelocityZLocal");

--- a/Tests/Editor/VRC3CVRVelocityCompatTests.cs
+++ b/Tests/Editor/VRC3CVRVelocityCompatTests.cs
@@ -47,6 +47,14 @@ public class VRC3CVRVelocityCompatTests
         Assert.AreEqual("#LocalX", walkedTree.blendParameter);
         Assert.AreEqual("VelocityZ", walkedTree.blendParameterY, "マッピングに無い名前は触らない");
 
+        // WalkParameterNames must only redirect layer REFERENCES, never the parameter
+        // DECLARATIONS (VRC3CVRCore.cs:1296-1299) — VelocityX/VelocityZ are the client-fed inputs
+        // the feed layer's derived values are computed from, so losing the declaration here would
+        // silently break that feed layer.
+        var declaredNames = controller.parameters.Select(p => p.name).ToArray();
+        CollectionAssert.Contains(declaredNames, "VelocityX");
+        CollectionAssert.Contains(declaredNames, "VelocityZ");
+
         Object.DestroyImmediate(controller);
     }
 

--- a/Tests/Editor/VRC3CVRVelocityCompatTests.cs
+++ b/Tests/Editor/VRC3CVRVelocityCompatTests.cs
@@ -168,5 +168,37 @@ public class VRC3CVRVelocityCompatTests
 
         Object.DestroyImmediate(controller);
     }
+
+    [Test]
+    public void RemapVelocity_DoesNotCorruptAnAlreadyGeneratedVelocityMagnitudeLayer()
+    {
+        var controller = new AnimatorController { name = "remapAfterMagnitudeTest" };
+        controller.AddParameter("VelocityMagnitude", AnimatorControllerParameterType.Float);
+        var core = MakeCore(controller);
+
+        // Reproduce the exact hazard: a vrc3cvr-generated feed layer with its own literal
+        // VelocityX/Y/Z reads already exists by the time the remap runs (this is the actual order
+        // Convert() uses — MakeVelocityMagnitudeFeedLayer before RemapVelocityToAvatarLocal). The
+        // remap must not rewrite that layer's own reads, nor mistake them for avatar usage.
+        typeof(VRC3CVRCore).GetMethod("MakeVelocityMagnitudeFeedLayer", Flags).Invoke(core, null);
+        typeof(VRC3CVRCore).GetMethod("RemapVelocityToAvatarLocal", Flags).Invoke(core, null);
+
+        var magnitudeLayer = controller.layers.Single(l => l.name.StartsWith("VRC3CVR_VelocityMagnitude"));
+        var driver = (ABI.CCK.Components.AnimatorDriver)magnitudeLayer.stateMachine.states.Single().state.behaviours.Single();
+        var referencedNames = driver.EnterTasks.SelectMany(t => new[] { t.aName, t.bName }).ToArray();
+        CollectionAssert.Contains(referencedNames, "VelocityX");
+        CollectionAssert.Contains(referencedNames, "VelocityZ");
+        CollectionAssert.DoesNotContain(referencedNames, "#VelocityXLocal",
+            "VelocityMagnitude レイヤー自身の読み取りは書き換えられてはいけない");
+        CollectionAssert.DoesNotContain(referencedNames, "#VelocityZLocal",
+            "VelocityMagnitude レイヤー自身の読み取りは書き換えられてはいけない");
+
+        // nothing outside the magnitude layer's own generated content references VelocityX/Z, so
+        // the remap must not manufacture a "used" signal purely from that layer's own reads
+        Assert.AreEqual(0, controller.layers.Count(l => l.name.StartsWith("VRC3CVR_LocomotionVelocity")),
+            "VelocityMagnitude の生成レイヤー自身の参照を「使用」と誤検知してはいけない");
+
+        Object.DestroyImmediate(controller);
+    }
 }
 #endif

--- a/Tests/Editor/VRC3CVRVelocityCompatTests.cs.meta
+++ b/Tests/Editor/VRC3CVRVelocityCompatTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c81b0fe3027a0fd448a01f683f73b811
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/VRC3CVRVerificationAvatar.cs
+++ b/Tests/Editor/VRC3CVRVerificationAvatar.cs
@@ -13,8 +13,9 @@ using VRC.SDKBase;
 // Generates a self-contained primitive humanoid avatar whose gimmicks make every in-game
 // verification item of the conversion observable (see the table in issue #17 / #21):
 //   G1 weight bar (analog squeeze) / G2 standalone weight condition (fixed 1 outside Fist)
-//   G3 weight condition paired with Fist / V1 VelocityMagnitude / S1 MuteSelf / S2 VRMode
-//   S3 Upright / C1..C6 the six constraint types / C7 Target Transform redirect
+//   G3 weight condition paired with Fist / V1 VelocityMagnitude / V2 avatar-local VelocityZ
+//   (forward vs strafe at an off-axis heading) / S1 MuteSelf / S2 VRMode / S3 Upright
+//   C1..C6 the six constraint types / C7 Target Transform redirect
 //   C8 same-type merge / C9 animated constraint properties (menu toggle)
 // Each group can be shown/hidden from the expressions menu so items can be checked one at a
 // time. Labels carry the expected behavior (in English: the built-in font has no CJK glyphs).
@@ -281,8 +282,8 @@ public static class VRC3CVRVerificationAvatar
 
         var state = new GameObject("State").transform;
         state.SetParent(panel, false);
-        Marker("VelocityBar", state, new Vector3(0.1f, 0f, 0f), new Vector3(0.05f, 0.02f, 0.05f), materials.green,
-            "grows with move speed\ncheck from a remote viewer too");
+        Marker("VelocityMagnitudeBar", state, new Vector3(0.1f, 0f, 0f), new Vector3(0.05f, 0.02f, 0.05f), materials.green,
+            "grows with move speed, any direction\ncheck from a remote viewer too");
         Marker("UprightBar", state, new Vector3(0.3f, 0f, 0f), new Vector3(0.05f, 0.02f, 0.05f), materials.blue,
             "shrinks while crouching / prone\ncheck from a remote viewer too");
         Marker("MuteMarker", state, new Vector3(0.5f, 0f, 0f), Vector3.one * 0.06f, materials.red,
@@ -290,6 +291,10 @@ public static class VRC3CVRVerificationAvatar
         Marker("VRMarker", state, new Vector3(0.7f, 0f, 0f), Vector3.one * 0.06f, materials.green,
             "green = wearer is in VR / blue = desktop\ncheck from a remote viewer too");
         Marker("DesktopMarker", state, new Vector3(0.7f, 0f, 0f), Vector3.one * 0.055f, materials.blue, null);
+        // avatar-local VelocityZ: proves the direction fix, not just the speed (V1 above uses
+        // VelocityMagnitude, which is frame-invariant and cannot tell forward from strafe)
+        Marker("VelocityBar", state, new Vector3(0.9f, 0f, 0f), new Vector3(0.05f, 0.02f, 0.05f), materials.white,
+            "walking forward raises this bar\nstrafing leaves it low, whatever heading you face");
     }
 
     // ---- constraint objects ----
@@ -631,6 +636,11 @@ public static class VRC3CVRVerificationAvatar
         fx.AddParameter("GestureLeft", AnimatorControllerParameterType.Int);
         fx.AddParameter("GestureLeftWeight", AnimatorControllerParameterType.Float);
         fx.AddParameter("VelocityMagnitude", AnimatorControllerParameterType.Float);
+        // referenced by V2's blend tree below: the parameter-name walker only rewrites
+        // Velocity{X,Z} to the derived avatar-local value where a layer actually reads them, so
+        // declaring them alone (with nothing consuming them) would not exercise the conversion
+        fx.AddParameter("VelocityX", AnimatorControllerParameterType.Float);
+        fx.AddParameter("VelocityZ", AnimatorControllerParameterType.Float);
         fx.AddParameter("Upright", AnimatorControllerParameterType.Float);
         fx.AddParameter("VRMode", AnimatorControllerParameterType.Int);
         fx.AddParameter("MuteSelf", AnimatorControllerParameterType.Bool);
@@ -766,10 +776,17 @@ public static class VRC3CVRVerificationAvatar
                 new[] { Cond("GestureLeftWeight", AnimatorConditionMode.Less, 0.5f) },
             });
 
-        // V1: velocity bar (0..4 m/s)
+        // V1: velocity magnitude bar (0..4 m/s, any direction)
         BlendTreeLayer("V1 Velocity", "VelocityMagnitude",
-            BarClip("V1_Low", "Panel/State/VelocityBar", 0.02f), 0f,
-            BarClip("V1_High", "Panel/State/VelocityBar", 0.4f), 4f);
+            BarClip("V1_Low", "Panel/State/VelocityMagnitudeBar", 0.02f), 0f,
+            BarClip("V1_High", "Panel/State/VelocityMagnitudeBar", 0.4f), 4f);
+
+        // V2: avatar-local VelocityZ bar (0..2 m/s, ChilloutVR's measured walk speed). Unlike V1,
+        // this is direction-sensitive: it should rise walking forward and stay low strafing,
+        // whatever the player's heading — the discriminating test the mod's V2 check runs
+        BlendTreeLayer("V2 VelocityZ", "VelocityZ",
+            BarClip("V2_Low", "Panel/State/VelocityBar", 0.02f), 0f,
+            BarClip("V2_High", "Panel/State/VelocityBar", 0.4f), 2f);
 
         // S3: upright bar
         BlendTreeLayer("S3 Upright", "Upright",

--- a/Tests/README.md
+++ b/Tests/README.md
@@ -32,6 +32,24 @@ gesture weights, parameter streams and animator-written parameters (AAP) are all
 behavior. This layer converts a purpose-built avatar, uploads it, and has a MelonLoader mod
 drive the game and machine-check the results.
 
+There are two avatars in this layer, and they answer different kinds of question:
+
+| Avatar | Built by | Path | Answers |
+| --- | --- | --- | --- |
+| Verification avatar | `VRC3CVRVerificationAvatar.cs` | VRChat avatar → **converted** → uploaded | Does the conversion produce an avatar that behaves correctly? |
+| CVR probe avatar | `VRC3CVRCvrProbeAvatar.cs` | ChilloutVR avatar → uploaded **as-is** | What does the ChilloutVR client hand an animator? |
+
+The probe deliberately skips the conversion. Its questions — the space and unit of the core
+velocity parameters, what each `CVRParameterStream` source reports, whether an `AnimatorDriver` can
+reconstruct an avatar-local velocity — are about the client, so putting the conversion in the path
+would only add a second thing that can be wrong. It is equally deliberate that the probe ships
+**inside an uploaded avatar** rather than being assembled at runtime by the mod: a component a mod
+adds to a worn avatar is not guaranteed to behave like one that shipped with it (the client may
+collect and initialise streams at avatar load, and may cache what each entry resolves against), so
+a runtime-assembled probe cannot settle a design question.
+
+The probe is optional — a run without a `probe=` id still checks the conversion in full.
+
 ### 2.1 Generate the verification avatar
 
 `Tools → VRC3CVR → Create Verification Avatar` builds a self-contained primitive humanoid
@@ -59,7 +77,11 @@ Unity project for the editor-side uploader), one per line:
 ```
 fold=<content id of the rewrite-mode avatar>
 derived=<content id of the derived-mode avatar>
+probe=<content id of the CVR probe avatar>
 ```
+
+The probe avatar is built by `Tools → VRC3CVR → Create CVR Probe Avatar` and uploaded with the CCK
+Control Panel with **no conversion step** — it is already a ChilloutVR avatar.
 
 Both the mod and the uploader refuse to run for an entry that is missing rather than creating a
 new avatar.
@@ -91,6 +113,8 @@ The suite switches to each avatar in turn and injects everything it needs — no
 | Gestures | `PlayerSetup.SetGestureLeft()`, re-applied every frame |
 | Walking | Harmony postfix on `CVRInputManager.UpdateInput` (the input system overwrites `movementVector` every frame, so a plain write loses the race). Diagonal, so `VelocityMagnitude` differs from every single axis and the sum of squares is actually proven |
 | Crouching | `BetterBetterCharacterController.crouching` |
+| Prone | Reflection on the character controller — the member is not guaranteed across client versions, so a rename degrades to "not measured" instead of breaking the build |
+| Heading | The player transform's rotation, re-asserted every frame (the movement system owns it otherwise). Used by M1 to tell an avatar-local `VelocityX/Z` from a world-space one: an axis-aligned heading makes both readings identical, so the test would pass for either |
 | Mute | `Comms_Manager.IsMicMuted` |
 | Menu toggles | `PlayerSetup.ChangeAnimatorParam()` |
 
@@ -99,6 +123,14 @@ Results are appended to `<ChilloutVR>\VRC3CVR_VerificationReport.txt` as `PASS` 
 
 ### 2.5 Reading the results
 
+- **Watch for the terminal marker, not for the file going quiet.** Each avatar's block ends with
+  `INFO done <timestamp>`, so a suite run is finished once that line appears once per avatar —
+  polling for "no growth for a while" adds that whole quiet period to the detection delay and can
+  leave the game running long after there is anything to wait for:
+  ```
+  f="<ChilloutVR>/VRC3CVR_VerificationReport.txt"
+  until [ "$(grep -c '^INFO done' "$f")" -ge 2 ]; do sleep 2; done
+  ```
 - The report is written **per avatar**, so a hang in a later avatar cannot lose earlier results
 - A coroutine cannot `try`/`catch` across a `yield`, so every synchronous block runs through a
   helper that turns an exception into a `FAIL` line instead of a silent death

--- a/VerificationMod~/Mod.cs
+++ b/VerificationMod~/Mod.cs
@@ -362,6 +362,75 @@ namespace VRC3CVRVerification
             });
             yield return new WaitForSeconds(1f);
 
+            // ---- V2: the CONVERTED blend tree actually reads the avatar-local velocity ----
+            // V1 above only proves #VelocityMagnitude (frame-invariant, unaffected by the local
+            // fix) tracks the raw axes. This proves the fix's actual output — VelocityBar, driven
+            // by the derived #VelocityZLocal — behaves correctly in the one place a magnitude
+            // check cannot: at a heading that is NOT axis-aligned. There, walking forward and
+            // strafing right put the same component on WORLD VelocityZ, so a conversion that fed
+            // the blend tree world-space velocity would raise the bar for both. Only reading the
+            // avatar-local value tells them apart. Shape reused from M1 below (heading forced and
+            // re-asserted every frame, since the movement system owns rotation otherwise).
+            Step("  V2 VelocityBar direction (walking, ~4s)");
+            // prefixed distinctly from M1's own playerTransform/originalRotation/heading below: a
+            // nested block in C# cannot reuse a name the enclosing method body also declares, even
+            // in a non-overlapping later statement (CS0136)
+            var v2PlayerTransform = BetterBetterCharacterController.Instance != null
+                ? BetterBetterCharacterController.Instance.transform
+                : (PlayerSetup.Instance != null ? PlayerSetup.Instance.transform : null);
+            var v2VelocityBar = avatar.Find("Panel/State/VelocityBar");
+            if (v2PlayerTransform == null || v2VelocityBar == null)
+            {
+                Run("V2", () => Note("V2 skipped: " + (v2PlayerTransform == null ? "no player transform" : "VelocityBar not found")));
+            }
+            else
+            {
+                var v2OriginalRotation = v2PlayerTransform.rotation;
+                var v2Heading = Quaternion.Euler(0f, v2PlayerTransform.eulerAngles.y + 40f, 0f);
+                var forwardPeak = 0f;
+                var strafePeak = 0f;
+
+                InjectMovement = true;
+                // forward, out and back so the strafe leg below starts from roughly the same spot
+                for (var i = 0; i < 120; i++)
+                {
+                    MovementOverride = new Vector3(0f, 0f, i < 60 ? 1f : -1f);
+                    // re-asserted every frame: the movement system owns the rotation otherwise
+                    v2PlayerTransform.rotation = v2Heading;
+                    yield return null;
+                    if (i > 20 && i < 60)
+                    {
+                        Run("V2 forward sample", () => forwardPeak = Mathf.Max(forwardPeak, v2VelocityBar.localScale.y));
+                    }
+                }
+                // strafe right, out and back, same heading
+                for (var i = 0; i < 120; i++)
+                {
+                    MovementOverride = new Vector3(i < 60 ? 1f : -1f, 0f, 0f);
+                    v2PlayerTransform.rotation = v2Heading;
+                    yield return null;
+                    if (i > 20 && i < 60)
+                    {
+                        Run("V2 strafe sample", () => strafePeak = Mathf.Max(strafePeak, v2VelocityBar.localScale.y));
+                    }
+                }
+                InjectMovement = false;
+                MovementOverride = Vector3.zero;
+                v2PlayerTransform.rotation = v2OriginalRotation;
+
+                Run("V2", () =>
+                {
+                    // 0.2 sits between the bar's short (0.02) and tall (0.4) scale — the same
+                    // threshold the G1 weight bar check uses to call a bar "tall"
+                    Check(forwardPeak > 0.2f,
+                        "V2 VelocityBar rises walking forward at a 40 deg heading (peak scaleY " + forwardPeak.ToString("0.000") + ")");
+                    Check(strafePeak < 0.2f,
+                        "V2 VelocityBar stays low strafing right at the same heading (peak scaleY " + strafePeak.ToString("0.000") +
+                        ", forward peak was " + forwardPeak.ToString("0.000") + ")");
+                });
+            }
+            yield return new WaitForSeconds(1f);
+
             // ---- M1/M3: the space and the unit of VelocityX/Y/Z (issue #28 go/no-go) ----
             // VRChat documents these as "Lateral / Vertical / Forward move speed in m/s", which is
             // avatar-LOCAL space. Converting a VRChat locomotion blend tree onto ChilloutVR's own

--- a/VerificationMod~/Mod.cs
+++ b/VerificationMod~/Mod.cs
@@ -420,11 +420,20 @@ namespace VRC3CVRVerification
 
                 Run("V2", () =>
                 {
-                    // 0.2 sits between the bar's short (0.02) and tall (0.4) scale — the same
-                    // threshold the G1 weight bar check uses to call a bar "tall"
-                    Check(forwardPeak > 0.2f,
+                    // The bar's map is linear: scaleY = 0.02 + (v / 2) * 0.38 for v in ChilloutVR's
+                    // documented m/s. Correct local-space forward reading approaches the walk speed
+                    // itself (2.0 m/s -> scaleY 0.4, the bar's full height). A regression to
+                    // world-space velocity puts sin(40 deg) ~= 0.64 of that speed on Z during the
+                    // strafe leg (2.0 * 0.64 = 1.28 m/s -> scaleY ~= 0.26). The old 0.2 threshold sat
+                    // at the exact midpoint of the range (needing >= 0.95 m/s forward), close enough
+                    // to a still-ramping sample window's plausible sub-peak reading to risk a spurious
+                    // failure on this test's first real run. 0.15 (>= 0.68 m/s) keeps real margin
+                    // under the ~0.4 a correct forward reading should approach, while staying well
+                    // clear of the ~0.26 a world-space regression reads on strafe, so the check that
+                    // exists to catch that regression still catches it.
+                    Check(forwardPeak > 0.15f,
                         "V2 VelocityBar rises walking forward at a 40 deg heading (peak scaleY " + forwardPeak.ToString("0.000") + ")");
-                    Check(strafePeak < 0.2f,
+                    Check(strafePeak < 0.15f,
                         "V2 VelocityBar stays low strafing right at the same heading (peak scaleY " + strafePeak.ToString("0.000") +
                         ", forward peak was " + forwardPeak.ToString("0.000") + ")");
                 });

--- a/VerificationMod~/Mod.cs
+++ b/VerificationMod~/Mod.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
@@ -133,28 +133,41 @@ namespace VRC3CVRVerification
             Step("suite starting; waiting 10s for the world to settle");
             yield return new WaitForSeconds(10f);
 
-            var avatars = new[] { ("Fold", ReadId("fold")), ("Derived", ReadId("derived")) };
-            var unconfigured = avatars.Where(entry => string.IsNullOrEmpty(entry.Item2)).ToArray();
+            // The probe avatar is ChilloutVR-native and answers client questions rather than
+            // conversion ones, so it carries a different readiness marker and a different routine.
+            // It is OPTIONAL: a run without it is still a complete conversion check.
+            var avatars = new (string label, string id, string marker, bool probe, bool required)[]
+            {
+                ("Fold", ReadId("fold"), "Constraints/AnimC", false, true),
+                ("Derived", ReadId("derived"), "Constraints/AnimC", false, true),
+                ("Probe", ReadId("probe"), "Armature/Hips", true, false),
+            };
+            var unconfigured = avatars.Where(entry => entry.required && string.IsNullOrEmpty(entry.id)).ToArray();
             if (unconfigured.Length > 0)
             {
-                var missing = string.Join(", ", unconfigured.Select(entry => entry.Item1.ToLower()));
+                var missing = string.Join(", ", unconfigured.Select(entry => entry.label.ToLower()));
                 File.AppendAllText(ReportPath, "FAIL no content id for " + missing + " in " +
                     Path.GetFullPath(IdFilePath) + " (write \"fold=<id>\" / \"derived=<id>\", one per line)\n");
                 Step("missing avatar ids in " + Path.GetFullPath(IdFilePath));
             }
-
-            foreach (var entry in avatars.Where(entry => !string.IsNullOrEmpty(entry.Item2)))
+            foreach (var entry in avatars.Where(entry => !entry.required && string.IsNullOrEmpty(entry.id)))
             {
-                Step("switching to the " + entry.Item1 + " avatar (" + entry.Item2 + ")");
-                AssetManagement.Instance.LoadLocalAvatar(entry.Item2);
-                // the switch is asynchronous and the previously worn avatar also carries the
+                File.AppendAllText(ReportPath, "INFO no content id for " + entry.label.ToLower() + " in " +
+                    Path.GetFullPath(IdFilePath) + "; skipping it (write \"" + entry.label.ToLower() + "=<id>\" to include it)\n");
+            }
+
+            foreach (var entry in avatars.Where(entry => !string.IsNullOrEmpty(entry.id)))
+            {
+                Step("switching to the " + entry.label + " avatar (" + entry.id + ")");
+                AssetManagement.Instance.LoadLocalAvatar(entry.id);
+                // the switch is asynchronous and the previously worn avatar also carries a
                 // verification rig, so wait for one whose object name carries this content id
                 var waited = 0f;
                 var lastLogged = 0f;
                 while (waited < 60f)
                 {
                     var loaded = PlayerSetup.Instance != null ? PlayerSetup.Instance.AvatarObject : null;
-                    if (loaded != null && loaded.name.Contains(entry.Item2) && loaded.transform.Find("Constraints/AnimC") != null)
+                    if (loaded != null && loaded.name.Contains(entry.id) && loaded.transform.Find(entry.marker) != null)
                     {
                         break;
                     }
@@ -163,23 +176,23 @@ namespace VRC3CVRVerification
                     {
                         lastLogged = waited;
                         var name = loaded != null ? loaded.name : "(none)";
-                        Step("  still waiting for " + entry.Item1 + " (" + waited.ToString("0") + "s, currently \"" + name + "\")");
+                        Step("  still waiting for " + entry.label + " (" + waited.ToString("0") + "s, currently \"" + name + "\")");
                     }
                     yield return null;
                 }
                 var avatar = PlayerSetup.Instance != null ? PlayerSetup.Instance.AvatarObject : null;
-                if (avatar == null || !avatar.name.Contains(entry.Item2) || avatar.transform.Find("Constraints/AnimC") == null)
+                if (avatar == null || !avatar.name.Contains(entry.id) || avatar.transform.Find(entry.marker) == null)
                 {
-                    File.AppendAllText(ReportPath, "FAIL " + entry.Item1 + ": verification avatar did not load within 60s (worn: \"" + (avatar != null ? avatar.name : "none") + "\")\n");
-                    Step(entry.Item1 + ": avatar did not load, skipping");
+                    File.AppendAllText(ReportPath, "FAIL " + entry.label + ": avatar did not load within 60s (worn: \"" + (avatar != null ? avatar.name : "none") + "\")\n");
+                    Step(entry.label + ": avatar did not load, skipping");
                     continue;
                 }
                 // give the avatar a moment to finish initializing after it appears
                 yield return new WaitForSeconds(2f);
-                Step(entry.Item1 + ": avatar loaded, running checks");
-                File.AppendAllText(ReportPath, "INFO ===== " + entry.Item1 + " mode (" + entry.Item2 + ") =====\n");
-                yield return RunChecks(avatar.transform);
-                Step(entry.Item1 + ": checks finished");
+                Step(entry.label + ": avatar loaded, running checks");
+                File.AppendAllText(ReportPath, "INFO ===== " + entry.label + " mode (" + entry.id + ") =====\n");
+                yield return entry.probe ? RunProbeChecks(avatar.transform) : RunChecks(avatar.transform);
+                Step(entry.label + ": checks finished");
             }
 
             File.AppendAllText(ReportPath, "INFO done " + DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss") + "\n");
@@ -349,6 +362,214 @@ namespace VRC3CVRVerification
             });
             yield return new WaitForSeconds(1f);
 
+            // ---- M1/M3: the space and the unit of VelocityX/Y/Z (issue #28 go/no-go) ----
+            // VRChat documents these as "Lateral / Vertical / Forward move speed in m/s", which is
+            // avatar-LOCAL space. Converting a VRChat locomotion blend tree onto ChilloutVR's own
+            // Velocity* only works if ChilloutVR means the same thing: an animator has no way to
+            // rotate a vector, so a world-space reading would make that design impossible.
+            //
+            // The player is turned to a heading that is deliberately NOT axis-aligned and walked
+            // forward, then the reported (VelocityX, VelocityZ) is compared against the player's
+            // real motion expressed BOTH ways. Real motion comes from the transform's own position
+            // delta, so this needs no client API beyond the transform — and the same samples answer
+            // the unit question, since that delta is metres per second by construction.
+            Step("  M1 velocity space");
+            var playerTransform = BetterBetterCharacterController.Instance != null
+                ? BetterBetterCharacterController.Instance.transform
+                : (PlayerSetup.Instance != null ? PlayerSetup.Instance.transform : null);
+            if (playerTransform == null)
+            {
+                Run("M1", () => Note("M1 skipped: no player transform"));
+            }
+            else
+            {
+                // 40 degrees off whatever the player faces now: axis-aligned headings make the two
+                // hypotheses numerically identical, which would read as a pass for either one
+                var originalRotation = playerTransform.rotation;
+                var heading = Quaternion.Euler(0f, playerTransform.eulerAngles.y + 40f, 0f);
+                var previousPosition = playerTransform.position;
+                var localErrorSum = 0f;
+                var worldErrorSum = 0f;
+                var separationSum = 0f;
+                var velocitySamples = 0;
+                var peakMeasuredSpeed = 0f;
+                var peakReportedSpeed = 0f;
+                // Raw evidence for the one thing the error sums cannot settle by themselves: WHICH
+                // transform the client measures against. "local" above is computed from the
+                // controller transform this test rotates, so if the client uses a different one —
+                // the avatar root, say — that never turned, the local hypothesis loses for the
+                // wrong reason. Logging the actual bearings makes the reference frame readable
+                // straight off the report: reported bearing == world bearing means world space,
+                // and reported == world minus a body's yaw means local space against that body.
+                var rawSamples = new List<string>();
+                var rawLogged = 0;
+                // M4: the salvage path for a world-space reading. The CCK documents
+                // RigidBodyLocalVelocityX/Y/Z as "Rigidbody velocity (local space)", resolved from
+                // "the Rigidbody that is on the same or in a parent GameObject relative to the
+                // Parameter Stream component" — so if the worn avatar has a Rigidbody above it, a
+                // stream on the avatar root hands the animator an avatar-local velocity directly,
+                // with no trigonometry layer. Whether one exists, and whether its transform turns
+                // with the player, is what decides that. Walking up the hierarchy answers both
+                // without touching the uploaded avatar.
+                Rigidbody ancestorBody = null;
+                var ancestry = new List<string>();
+                var ancestorBodies = new List<Rigidbody>();
+                for (var t = animator.transform; t != null; t = t.parent)
+                {
+                    var body = t.GetComponent<Rigidbody>();
+                    ancestry.Add(t.name + (body != null ? " [Rigidbody]" : ""));
+                    if (body != null)
+                    {
+                        ancestorBodies.Add(body);
+                        if (ancestorBody == null)
+                        {
+                            ancestorBody = body;
+                        }
+                    }
+                }
+
+                InjectMovement = true;
+                // out and back, so the player ends where it started: a one-way walk left the
+                // player ~7m downrange and the next avatar's run started against a wall
+                for (var i = 0; i < 180; i++)
+                {
+                    MovementOverride = new Vector3(0f, 0f, i < 90 ? 1f : -1f);
+                    // re-asserted every frame: the movement system owns the rotation otherwise
+                    playerTransform.rotation = heading;
+                    yield return null;
+                    var sample = i;
+                    Run("M1 sample", () =>
+                    {
+                        var position = playerTransform.position;
+                        var worldVelocity = Time.deltaTime > 0f
+                            ? (position - previousPosition) / Time.deltaTime
+                            : Vector3.zero;
+                        previousPosition = position;
+                        // let the player accelerate and the heading settle before believing
+                        // anything, and skip the turnaround for the same reason
+                        if (sample < 30 || (sample >= 90 && sample < 120))
+                        {
+                            return;
+                        }
+                        var groundSpeed = new Vector2(worldVelocity.x, worldVelocity.z).magnitude;
+                        if (groundSpeed < 0.5f)
+                        {
+                            return;
+                        }
+                        // measured against the CURRENT rotation, so the maths stays right even if
+                        // the client refused the injected heading
+                        var localVelocity = Quaternion.Inverse(playerTransform.rotation) * worldVelocity;
+                        var world = new Vector2(worldVelocity.x, worldVelocity.z);
+                        var local = new Vector2(localVelocity.x, localVelocity.z);
+                        var reported = new Vector2(ReadParam(animator, "VelocityX"), ReadParam(animator, "VelocityZ"));
+
+                        localErrorSum += (reported - local).magnitude;
+                        worldErrorSum += (reported - world).magnitude;
+                        separationSum += (world - local).magnitude;
+                        velocitySamples++;
+                        peakMeasuredSpeed = Mathf.Max(peakMeasuredSpeed, groundSpeed);
+                        peakReportedSpeed = Mathf.Max(peakReportedSpeed, reported.magnitude);
+
+                        if (rawLogged < 5 && sample % 25 == 0 && reported.magnitude > 0.5f)
+                        {
+                            rawLogged++;
+                            // bearings measured the Unity way: 0 is +Z, growing clockwise
+                            var worldBearing = Mathf.Atan2(world.x, world.y) * Mathf.Rad2Deg;
+                            var reportedBearing = Mathf.Atan2(reported.x, reported.y) * Mathf.Rad2Deg;
+                            rawSamples.Add("M1 raw f" + sample +
+                                ": controller yaw " + playerTransform.eulerAngles.y.ToString("0.0") +
+                                ", avatar yaw " + animator.transform.eulerAngles.y.ToString("0.0") +
+                                ", world bearing " + worldBearing.ToString("0.0") +
+                                ", reported bearing " + reportedBearing.ToString("0.0") +
+                                ", world-reported " + Mathf.DeltaAngle(reportedBearing, worldBearing).ToString("0.0") +
+                                " deg, |world| " + world.magnitude.ToString("0.00") +
+                                ", |reported| " + reported.magnitude.ToString("0.00"));
+                            // EVERY Rigidbody in the chain, not just the nearest: if the nearest is
+                            // kinematic the stream may still be resolving to a different one, and
+                            // "the nearest one reads zero" is not the same claim as "no body in the
+                            // hierarchy carries the motion"
+                            foreach (var body in ancestorBodies)
+                            {
+                                var bodyLocal = body.transform.InverseTransformDirection(body.velocity);
+                                rawSamples.Add("M4 raw f" + sample + ": rigidbody \"" + body.name +
+                                    "\" kinematic " + body.isKinematic +
+                                    ", yaw " + body.transform.eulerAngles.y.ToString("0.0") +
+                                    ", world velocity (" + body.velocity.x.ToString("0.00") + ", " +
+                                    body.velocity.z.ToString("0.00") +
+                                    "), LOCAL velocity (" + bodyLocal.x.ToString("0.00") + ", " +
+                                    bodyLocal.z.ToString("0.00") + ")");
+                            }
+                            // M6: the conversion that needs no yaw and no trigonometry. ChilloutVR's
+                            // MovementX/Y are NORMALISED MOVEMENT INPUT, which is player-local by
+                            // construction, and a magnitude is frame-independent — so
+                            // (MovementX, MovementY) * |world velocity| should reconstruct exactly
+                            // the avatar-local velocity VRChat's locomotion trees expect. Checked
+                            // against the reported world vector rotated by the avatar's own yaw,
+                            // which keeps both sides free of position-sampling noise.
+                            var inputVector = new Vector2(
+                                ReadParam(animator, "MovementX"), ReadParam(animator, "MovementY"));
+                            var trueLocal3 = Quaternion.Euler(0f, -animator.transform.eulerAngles.y, 0f)
+                                * new Vector3(reported.x, 0f, reported.y);
+                            var trueLocal = new Vector2(trueLocal3.x, trueLocal3.z);
+                            var reconstructed = inputVector * reported.magnitude;
+                            rawSamples.Add("M6 raw f" + sample + ": MovementX/Y (" +
+                                inputVector.x.ToString("0.00") + ", " + inputVector.y.ToString("0.00") +
+                                "), speed " + reported.magnitude.ToString("0.00") +
+                                " -> reconstructed local (" + reconstructed.x.ToString("0.00") + ", " +
+                                reconstructed.y.ToString("0.00") +
+                                ") vs true local (" + trueLocal.x.ToString("0.00") + ", " +
+                                trueLocal.y.ToString("0.00") + ")");
+                        }
+                    });
+                }
+                InjectMovement = false;
+                MovementOverride = Vector3.zero;
+                playerTransform.rotation = originalRotation;
+                Run("M1", () =>
+                {
+                    if (velocitySamples == 0)
+                    {
+                        Note("M1 inconclusive: the player never reached a measurable speed");
+                        return;
+                    }
+                    var localError = localErrorSum / velocitySamples;
+                    var worldError = worldErrorSum / velocitySamples;
+                    var separation = separationSum / velocitySamples;
+                    foreach (var raw in rawSamples)
+                    {
+                        Note(raw);
+                    }
+                    Note("M1 read the raw lines as: world-reported ~0 means WORLD space; " +
+                         "world-reported ~= a body's yaw means LOCAL space against that body");
+                    Note("M4 hierarchy above the avatar: " + string.Join(" < ", ancestry.ToArray()));
+                    Note(ancestorBody != null
+                        ? "M4 a Rigidbody exists at or above the avatar (\"" + ancestorBody.name +
+                          "\"), so a CVRParameterStream RigidBodyLocalVelocity* on the avatar root would resolve to it. " +
+                          "Usable only if its LOCAL velocity above tracks the walk direction while its yaw turns with the player"
+                        : "M4 NO Rigidbody at or above the avatar — RigidBodyLocalVelocity* cannot resolve, so a " +
+                          "world-to-local conversion would have to be built from the transform yaw instead");
+                    Note("M1 samples " + velocitySamples +
+                         ", mean |reported - local| " + localError.ToString("0.000") +
+                         " m/s, mean |reported - world| " + worldError.ToString("0.000") +
+                         " m/s, mean |local - world| " + separation.ToString("0.000") + " m/s");
+                    // without separation the two hypotheses predict the same numbers and neither
+                    // result would mean anything
+                    if (separation < 0.5f)
+                    {
+                        Note("M1 INCONCLUSIVE: the two hypotheses were only " + separation.ToString("0.000") +
+                             " m/s apart — the injected heading did not take, so this run proves nothing");
+                        return;
+                    }
+                    Check(localError < worldError * 0.5f,
+                        "M1 ChilloutVR reports VelocityX/Z in AVATAR-LOCAL space, as VRChat does (local error " +
+                        localError.ToString("0.000") + " vs world error " + worldError.ToString("0.000") + " m/s)");
+                    Note("M3 peak measured ground speed " + peakMeasuredSpeed.ToString("0.00") +
+                         " m/s vs peak reported |VelocityXZ| " + peakReportedSpeed.ToString("0.00") +
+                         " — equal means ChilloutVR reports metres per second, as VRChat does");
+                });
+                yield return new WaitForSeconds(1f);
+            }
+
             // ---- S3: upright while crouching (injected) ----
             Step("  S3 crouch");
             var uprightStanding = 0f;
@@ -375,6 +596,57 @@ namespace VRC3CVRVerification
                 characterController.crouching = false;
             });
             yield return new WaitForSeconds(1.5f);
+
+            // ---- M2: what Upright actually READS for each ChilloutVR stance (issue #28) ----
+            // S3 only proves Upright moves. The integration feeds VRChat's Upright from
+            // ChilloutVR's AvatarUpright stream, and VRChat's stock locomotion switches stance at
+            // specific values — 0.68/0.70 between standing and crouching, 0.41/0.43 between
+            // crouching and prone — so a ChilloutVR crouch has to LAND in VRChat's crouch band or
+            // the converted state machine picks the wrong stance. These are the numbers that decide
+            // whether the stream can be used directly or has to be remapped.
+            Step("  M2 upright values");
+            if (characterController == null)
+            {
+                Run("M2", () => Note("M2 skipped: no character controller"));
+            }
+            else
+            {
+                var uprightStand = float.NaN;
+                var uprightCrouch = float.NaN;
+                var uprightProne = float.NaN;
+                var proneInjected = false;
+                Run("M2 standing", () => uprightStand = ReadParam(animator, "Upright"));
+                Run("M2 crouch on", () => characterController.crouching = true);
+                yield return new WaitForSeconds(1.5f);
+                Run("M2 crouch read", () =>
+                {
+                    uprightCrouch = ReadParam(animator, "Upright");
+                    characterController.crouching = false;
+                });
+                yield return new WaitForSeconds(1.5f);
+                Run("M2 prone on", () => proneInjected = TrySetBool(characterController, "prone", true));
+                yield return new WaitForSeconds(1.5f);
+                Run("M2 prone read", () =>
+                {
+                    if (!proneInjected)
+                    {
+                        return;
+                    }
+                    uprightProne = ReadParam(animator, "Upright");
+                    TrySetBool(characterController, "prone", false);
+                });
+                yield return new WaitForSeconds(1.5f);
+                Run("M2", () =>
+                {
+                    Note("M2 Upright reads — standing " + uprightStand.ToString("0.000") +
+                         ", crouching " + uprightCrouch.ToString("0.000") +
+                         ", prone " + (proneInjected ? uprightProne.ToString("0.000") : "n/a (no writable 'prone' on the controller)"));
+                    Note("M2 VRChat stock bands for comparison — standing > 0.70, crouching 0.43..0.68, prone < 0.41");
+                    Check(uprightCrouch > 0.43f && uprightCrouch < 0.68f,
+                        "M2 a ChilloutVR crouch lands inside VRChat's crouch band, so the stream can drive a converted locomotion layer unremapped (" +
+                        uprightCrouch.ToString("0.000") + ")");
+                });
+            }
 
             // ---- S1: mute (injected) ----
             Step("  S1 mute");
@@ -496,6 +768,195 @@ namespace VRC3CVRVerification
             _running = false;
         }
 
+        // The ChilloutVR-NATIVE probe avatar (built by VRC3CVRCvrProbeAvatar, uploaded as-is).
+        // Nothing here passes through the conversion, so every reading is a statement about what
+        // the client hands an animator — which is the only thing these questions are about.
+        IEnumerator RunProbeChecks(Transform avatar)
+        {
+            _running = true;
+            _report.Clear();
+            Note("probe started for " + avatar.name);
+            Step("  probe settling (3s)");
+            yield return new WaitForSeconds(3f);
+
+            Animator animator = null;
+            for (var attempt = 0; attempt < 20 && animator == null; attempt++)
+            {
+                Run("probe resolve animator", () => animator = avatar.GetComponentInChildren<Animator>(true));
+                if (animator == null)
+                {
+                    yield return new WaitForSeconds(0.5f);
+                }
+            }
+            if (animator == null)
+            {
+                Check(false, "probe: no Animator found on the avatar");
+                Flush();
+                _running = false;
+                yield break;
+            }
+            Run("probe params", () => Note("probe animator parameters: " + string.Join(", ",
+                animator.parameters.Select(p => p.name + ":" + p.type).ToArray())));
+
+            var playerTransform = BetterBetterCharacterController.Instance != null
+                ? BetterBetterCharacterController.Instance.transform
+                : avatar;
+            var probeOriginalRotation = playerTransform.rotation;
+
+            // ---- P1: the range and reference of TransformGlobalRotationY ----
+            // The CCK documents the value range of the Transform rotation sources as unknown, so
+            // it is read at two known headings: one reading cannot tell 0..360 from -180..180, and
+            // an axis-aligned heading cannot tell a live source from a dead one.
+            Step("  P1 world yaw source");
+            foreach (var heading in new[] { 200f, 40f })
+            {
+                var wanted = heading;
+                Run("P1 turn", () => playerTransform.rotation = Quaternion.Euler(0f, wanted, 0f));
+                yield return new WaitForSeconds(1.5f);
+                Run("P1 read", () => Note("P1 at heading " + wanted.ToString("0") +
+                    ": TransformGlobalRotationY reads " + ReadParam(animator, "PrbWorldYaw").ToString("0.00") +
+                    ", controller yaw " + playerTransform.eulerAngles.y.ToString("0.0") +
+                    ", avatar root yaw " + animator.transform.eulerAngles.y.ToString("0.0")));
+            }
+            Run("P1 upright", () => Note("P1 AvatarUpright source reads " +
+                ReadParam(animator, "PrbUpright").ToString("0.000") + " while standing"));
+
+            // ---- P2: does the reconstruction hold, and is the Rigidbody route alive? ----
+            // Walked at a heading that is not axis-aligned, out and back so the player ends where
+            // it started. Ground truth is the reported WORLD velocity rotated by the avatar's own
+            // yaw: both sides then come from the client, with no position-sampling noise.
+            Step("  P2 reconstruction (walking, ~3s)");
+            var reconErrorSum = 0f;
+            var rbLocalErrorSum = 0f;
+            var inputMatchSum = 0f;
+            var probeSamples = 0;
+            var rbAnyMotion = 0f;
+            var probeRaw = new List<string>();
+            var probeLogged = 0;
+
+            InjectMovement = true;
+            for (var i = 0; i < 180; i++)
+            {
+                MovementOverride = new Vector3(0f, 0f, i < 90 ? 1f : -1f);
+                playerTransform.rotation = Quaternion.Euler(0f, 40f, 0f);
+                yield return null;
+                var sample = i;
+                Run("P2 sample", () =>
+                {
+                    if (sample < 30 || (sample >= 90 && sample < 120))
+                    {
+                        return;
+                    }
+                    var world = new Vector2(ReadParam(animator, "VelocityX"), ReadParam(animator, "VelocityZ"));
+                    if (world.magnitude < 0.5f)
+                    {
+                        return;
+                    }
+                    var trueLocal3 = Quaternion.Euler(0f, -animator.transform.eulerAngles.y, 0f)
+                        * new Vector3(world.x, 0f, world.y);
+                    var trueLocal = new Vector2(trueLocal3.x, trueLocal3.z);
+                    var recon = new Vector2(ReadParam(animator, "PrbReconX"), ReadParam(animator, "PrbReconZ"));
+                    var rbLocal = new Vector2(ReadParam(animator, "PrbRbLocalVelX"), ReadParam(animator, "PrbRbLocalVelZ"));
+                    var core = new Vector2(ReadParam(animator, "MovementX"), ReadParam(animator, "MovementY"));
+                    var input = new Vector2(ReadParam(animator, "PrbInputMoveX"), ReadParam(animator, "PrbInputMoveY"));
+
+                    reconErrorSum += (recon - trueLocal).magnitude;
+                    rbLocalErrorSum += (rbLocal - trueLocal).magnitude;
+                    inputMatchSum += (input - core).magnitude;
+                    // every Rigidbody readout, not just the local pair: "the local variant is zero"
+                    // is a weaker claim than "the body carries no motion at all"
+                    var rbWorld = new Vector2(ReadParam(animator, "PrbRbVelX"), ReadParam(animator, "PrbRbVelZ"));
+                    rbAnyMotion = Mathf.Max(rbAnyMotion, Mathf.Max(
+                        Mathf.Max(rbLocal.magnitude, rbWorld.magnitude),
+                        ReadParam(animator, "PrbRbSpeed")));
+                    probeSamples++;
+
+                    if (probeLogged < 4 && sample % 25 == 0)
+                    {
+                        probeLogged++;
+                        probeRaw.Add("P2 raw f" + sample +
+                            ": world (" + world.x.ToString("0.00") + ", " + world.y.ToString("0.00") +
+                            "), true local (" + trueLocal.x.ToString("0.00") + ", " + trueLocal.y.ToString("0.00") +
+                            "), recon (" + recon.x.ToString("0.00") + ", " + recon.y.ToString("0.00") +
+                            "), rb local (" + rbLocal.x.ToString("0.00") + ", " + rbLocal.y.ToString("0.00") +
+                            "), rb world (" + ReadParam(animator, "PrbRbVelX").ToString("0.00") + ", " +
+                            ReadParam(animator, "PrbRbVelZ").ToString("0.00") +
+                            "), rb speed " + ReadParam(animator, "PrbRbSpeed").ToString("0.00") +
+                            ", MovementX/Y (" + core.x.ToString("0.00") + ", " + core.y.ToString("0.00") +
+                            "), InputMovement (" + input.x.ToString("0.00") + ", " + input.y.ToString("0.00") +
+                            "), derived speed " + ReadParam(animator, "PrbSpeed").ToString("0.00") +
+                            ", movement ring " + ReadParam(animator, "PrbMoveMag").ToString("0.00"));
+                    }
+                });
+            }
+            InjectMovement = false;
+            MovementOverride = Vector3.zero;
+
+            // ---- P3: the axis and sign convention, which a forward-only walk cannot show ----
+            Step("  P3 strafe convention");
+            var strafeLine = "P3 not sampled";
+            InjectMovement = true;
+            for (var i = 0; i < 60; i++)
+            {
+                MovementOverride = new Vector3(1f, 0f, 0f);
+                playerTransform.rotation = Quaternion.Euler(0f, 40f, 0f);
+                yield return null;
+                var sample = i;
+                Run("P3 sample", () =>
+                {
+                    if (sample != 45)
+                    {
+                        return;
+                    }
+                    var world = new Vector2(ReadParam(animator, "VelocityX"), ReadParam(animator, "VelocityZ"));
+                    var trueLocal3 = Quaternion.Euler(0f, -animator.transform.eulerAngles.y, 0f)
+                        * new Vector3(world.x, 0f, world.y);
+                    strafeLine = "P3 strafing right: true local (" + trueLocal3.x.ToString("0.00") + ", " +
+                        trueLocal3.z.ToString("0.00") + "), MovementX/Y (" +
+                        ReadParam(animator, "MovementX").ToString("0.00") + ", " +
+                        ReadParam(animator, "MovementY").ToString("0.00") + "), recon (" +
+                        ReadParam(animator, "PrbReconX").ToString("0.00") + ", " +
+                        ReadParam(animator, "PrbReconZ").ToString("0.00") + ")";
+                });
+            }
+            InjectMovement = false;
+            MovementOverride = Vector3.zero;
+            playerTransform.rotation = probeOriginalRotation;
+
+            Run("P2", () =>
+            {
+                foreach (var raw in probeRaw)
+                {
+                    Note(raw);
+                }
+                Note(strafeLine);
+                if (probeSamples == 0)
+                {
+                    Note("P2 inconclusive: the player never reached a measurable speed");
+                    return;
+                }
+                var reconError = reconErrorSum / probeSamples;
+                var rbLocalError = rbLocalErrorSum / probeSamples;
+                var inputMatch = inputMatchSum / probeSamples;
+                Note("P2 samples " + probeSamples +
+                     ", mean |recon - true local| " + reconError.ToString("0.000") +
+                     " m/s, mean |rb local - true local| " + rbLocalError.ToString("0.000") +
+                     " m/s, mean |InputMovement - MovementX/Y| " + inputMatch.ToString("0.000"));
+                Check(reconError < 0.25f,
+                    "P2 (MovementX, MovementY) x ground speed reconstructs the avatar-local velocity VRChat's " +
+                    "locomotion trees expect, with no yaw and no trigonometry (mean error " +
+                    reconError.ToString("0.000") + " m/s)");
+                Note(rbAnyMotion > 0.25f
+                    ? "P2 the Rigidbody sources DO carry motion (peak " + rbAnyMotion.ToString("0.00") +
+                      "); mean local error " + rbLocalError.ToString("0.000") + " m/s says whether they are avatar-local"
+                    : "P2 the Rigidbody sources report no motion at all (peak " + rbAnyMotion.ToString("0.00") +
+                      ") — RigidBodyLocalVelocity* cannot drive a converted locomotion layer");
+            });
+
+            Flush();
+            _running = false;
+        }
+
         IEnumerator Gesture(Transform avatar, Animator animator, float value, string label, bool weightBarTall, bool weightGate, bool fistGate, float derivedWeight)
         {
             _gestureOverride = value;
@@ -560,6 +1021,32 @@ namespace VRC3CVRVerification
             }
             var value = ReadParam(animator, name);
             Check(Mathf.Abs(value - expected) < tolerance, message + " (value " + value.ToString("0.00") + ")");
+        }
+
+        // Writes a bool member whose existence is not guaranteed across client versions, so a
+        // renamed or absent field degrades to "not measured" instead of failing the build.
+        static bool TrySetBool(object target, string name, bool value)
+        {
+            if (target == null)
+            {
+                return false;
+            }
+            const System.Reflection.BindingFlags Flags = System.Reflection.BindingFlags.Public
+                | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance;
+            var type = target.GetType();
+            var field = type.GetField(name, Flags);
+            if (field != null && field.FieldType == typeof(bool))
+            {
+                field.SetValue(target, value);
+                return true;
+            }
+            var property = type.GetProperty(name, Flags);
+            if (property != null && property.PropertyType == typeof(bool) && property.CanWrite)
+            {
+                property.SetValue(target, value, null);
+                return true;
+            }
+            return false;
         }
 
         // GetFloat only works on float parameters; bools and ints silently read back as 0


### PR DESCRIPTION
VRChat のレイヤーが読む `VelocityX` / `VelocityZ` を、ChilloutVR がワールド座標系で渡してくる速度から再構成したアバターローカル値に差し替える。

設計と実測の全経緯は #28 に記録してある。

## 何が問題だったか

ChilloutVR は `VelocityX/Y/Z` を animator に供給する。VRChat も同名のパラメータを持ち、公式ドキュメントは "Lateral / Vertical / Forward move speed in m/s" と定義している ─ アバターローカル座標系である。名前も単位も一致しているので、そのまま繋がるように見える。

**繋がらない。ChilloutVR が渡してくるのはワールド座標系の速度だった。**

実機で測った結果:

```
プレイヤーを 40° の向きに固定して前進
  → 報告された (VelocityX, VelocityZ) の方位角 = 40.1°
  → ワールドの移動方位角と完全に一致（差 0.0°、後退時の -140° への反転も追従）
  → アバターローカルなら報告方位角は 0°、差は 40°（= yaw）になるはずだった
```

このまま VRChat の locomotion ブレンドツリーに渡すと、**アバターが北を向いて歩けば「前進」、東を向いて歩けば「右ストレイフ」**と解釈される。向きによってアニメーションが変わってしまい、使い物にならない。

## どう直したか

再構成した値を `VelocityX/Z` に書き戻すことはできない ─ クライアントが毎フレーム上書きする。そこで導出パラメータに書き、変換後のレイヤー側の参照をそちらへ差し替える。

```
speed  = √(VelocityX² + VelocityZ²)      … 地上速度。大きさなので座標系に依存しない
ring   = √(MovementX² + MovementY²)      … 歩き 0.5 / 走り 1.0
scale  = speed / (ring + 0.0001)
#VelocityXLocal = MovementX × scale
#VelocityZLocal = MovementY × scale
```

方向は ChilloutVR の `MovementX/Y` から取る。これは移動「入力」なので定義上プレイヤーローカルで、軸と符号も VRChat と一致する（+X = 右、+Y = 前）。ただし**単位ベクトルではなく歩き 0.5 / 走り 1.0 のリング**なので、方向だけを使い大きさは速度から取る。ここは実機で読むまで気づけず、最初に立てた `MovementX/Y × speed` という式は歩行時に真値の半分を返していた。

`AnimatorDriver` の算術（乗算・加算・冪・除算）だけで済む。yaw も三角関数も追加のパラメータストリームも要らない。**`MovementX/Y` と `VelocityX/Y/Z` はどちらも ChilloutVR の core parameter なので、リモート同期の追加コストはゼロ。**

イプシロンは停止時の 0 除算回避で、停止時は分子（speed）も 0 なので scale も 0 に落ちる。

`VelocityY` と `VelocityMagnitude` は触らない。プレイヤーは Y 軸まわりにしか回らないので鉛直成分は両座標系で同値であり、大きさに向きは無い。

## 検討して落とした代替案

- **`RigidBodyLocalVelocity*`**（CCK のパラメータストリーム、"local space" と明記されている）: 実機で恒常的にゼロ。ChilloutVR の character controller は kinematic な Rigidbody を動かすため `Rigidbody.velocity` が更新されない
- **`TransformGlobalRotationY` + sin/cos のブレンドツリー近似**でワールド→ローカル変換: 成立はする（値域は度数 0〜360 で、コンポーネントを置いた transform を読むことを確認済み）が、上の式で足りるので不要
- **`InputMovementX/Y`**（生の正規化入力 ±1.0）: 同じ答えになるが stream ＝装着者のみなので、core parameter を使う方を採った

## コミット構成

| | |
|---|---|
| `e59ca5e` | 実測の土台。ChilloutVR ネイティブの probe アバター（変換を経由せずアップロードする）と検証モッドの読み出し。上の測定値はこれで得た |
| `993a206` | パラメータ名書き換えウォーカーを任意のマッピングで再利用できるようにする |
| `7ea6003` | ローカル速度を導出する `AnimatorDriver` レイヤー |
| `0e6cbbd` | 変換後のレイヤーの参照を導出値へ差し替える |
| `27b5dae` | 差し替えが自分で生成したレイヤーを壊さないようにする |
| `fba3a24` | 生成レイヤーを名前の接頭辞ではなく明示的に追跡する |
| `c805aad` | 実機検査（V2）を検証アバターとモッドに追加 |
| `3a01822` | レビュー指摘2件の修正 |

## レビューで見つかった不具合

途中のレビューが、机上では見えていなかった問題を2件捕まえている。

**差し替えパスが自分の生成物を壊していた** (`27b5dae`)。`WalkParameterNames` はコントローラの全レイヤーを走査するので、同じ `Convert()` が直前に生成した `VRC3CVR_VelocityMagnitude` レイヤーの driver タスク（ワールド速度を読むべき `VelocityX/Z`）まで書き換えてしまっていた。結果、①magnitude が 1 フレーム古いローカル値を読む ②`uses` が自己検出で真になり、**`VelocityMagnitude` を使うだけのアバター全部に不要な locomotion レイヤーが生える**。既存の E2E テストはレイヤー名の存在しか見ていないため素通りしていた。

**その修正が新たな回帰面を作っていた** (`fba3a24`)。生成レイヤーの識別に `VRC3CVR_` という名前の接頭辞を使ったが、レイヤー名はアバター作者が自由に付けられる。同じ接頭辞のレイヤーが誤って除外され、まさにこの PR が直そうとしているバグが無診断で再現する経路になっていた。生成時に `HashSet` へ記録する形に変え、追加箇所を1つの choke point に集約したので、将来レイヤー追加を書く人が接頭辞を忘れても壊れない。

## テスト

EditMode 140 件が緑。新規は 7 件で、うち 2 件は上記2つの不具合の回帰テスト（危険な呼び出し順を再現するもの、および `VRC3CVR_MyCoolLayer` という名前のソースレイヤーが正しく書き換えられることを確認するもの）。どちらも対応する修正が無ければ実際に落ちることを確認済み。

ブランチ全体のレビューで、既定経路（`parameterRenamer == null`）が速度を読まないアバターに対してアロケーションすら発生しない真の no-op であること、CCK が残すレイヤーが `VelocityX/Z` を1件も参照しないので誤検出しないことを確認している。

## 未完了 ─ マージ前に把握しておくこと

**実機検査（V2）はまだ走っていない。** 検証アバターの再変換・再アップロードと ChilloutVR の起動という人手の作業が要るため。

現時点で式の正しさを裏づけているのは probe アバターによる先の測定（120 サンプル・平均誤差 0.000 m/s）であって、このブランチ自身の検査ではない。ユニットテストは animator が意図どおり組まれることは証明するが、**式が間違っていても検出できない**。リリースタグを打つ前に V2 を通すべき。

V2 は 40° の向きで前進と右ストレイフを区別する。ワールド座標系のままなら後者が落ちる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
