### PR TITLE
VRChat の Additive playable の2つの規則を再現する

### DIFF
--- a/Editor/VRC3CVRCore.cs
+++ b/Editor/VRC3CVRCore.cs
@@ -2545,7 +2545,11 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
             case VRCBaseAnimatorID.BASE:
                 return GetCombinedAvatarMask(ReplaceVRCMask(fullMask), ReplaceVRCMask(originalMask));
             case VRCBaseAnimatorID.ADDITIVE:
-                return GetCombinedAvatarMask(ReplaceVRCMask(fullMask), ReplaceVRCMask(originalMask));
+                // VRChat ignores the Additive playable's first layer mask, so the avatar was
+                // authored with that mask having no effect.
+                return layerID == 0
+                    ? ReplaceVRCMask(fullMask)
+                    : GetCombinedAvatarMask(ReplaceVRCMask(fullMask), ReplaceVRCMask(originalMask));
             case VRCBaseAnimatorID.GESTURE:
                 if (layerID == 0)
                 {

--- a/Editor/VRC3CVRCore.cs
+++ b/Editor/VRC3CVRCore.cs
@@ -2604,6 +2604,14 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
                 newAnimatorController.parameters = parameters;
 
                 layer.avatarMask = GetAvatarMaskForLayerAndVRCAnimator(animatorID, i, layer.avatarMask);
+                if (animatorID == VRCBaseAnimatorID.ADDITIVE)
+                {
+                    // The Additive playable is additive by platform rule, not by anything in the
+                    // controller, so an author's layers are usually left on Override. Every layer
+                    // becomes additive rather than only the first: one that stayed on Override
+                    // would replace the whole merged pose, not just the additive contribution.
+                    layer.blendingMode = AnimatorLayerBlendingMode.Additive;
+                }
                 controllerLayers[i] = layer;
                 layersModified = true;
             }

--- a/Tests/Editor/VRC3CVRBehaviourConversionTests.cs
+++ b/Tests/Editor/VRC3CVRBehaviourConversionTests.cs
@@ -610,6 +610,41 @@ public class VRC3CVRBehaviourConversionTests
         Assert.IsFalse(result1.GetHumanoidBodyPartActive(AvatarMaskBodyPart.RightArm), "layer 0's baseline excluded RightArm, so layer 1 must not override it");
     }
 
+    [TestCase(VRC3CVRCore.VRCBaseAnimatorID.ADDITIVE, AnimatorLayerBlendingMode.Additive)]
+    [TestCase(VRC3CVRCore.VRCBaseAnimatorID.FX, AnimatorLayerBlendingMode.Override)]
+    public void MergeVrcAnimator_ForcesAdditiveBlendingOnlyForTheAdditivePlayable(
+        VRC3CVRCore.VRCBaseAnimatorID animatorID, AnimatorLayerBlendingMode expected)
+    {
+        var core = new VRC3CVRCore();
+        SetPrivateField(core, "fullMask", MakeMask("Full", AvatarMaskBodyPart.LeftArm));
+        SetPrivateField(core, "musclesOnlyMask", MakeMask("Muscles", AvatarMaskBodyPart.LeftArm));
+        SetPrivateField(core, "emptyMask", MakeMask("Empty"));
+        var target = new AnimatorController { name = "target" };
+        SetPrivateField(core, "chilloutAnimatorController", target);
+
+        // an author's Additive controller normally leaves its layers on Override — the platform,
+        // not the controller, is what makes the playable additive
+        var source = new AnimatorController { name = "source" };
+        source.AddLayer("L0");
+        source.AddLayer("L1");
+        var sourceLayers = source.layers;
+        sourceLayers[0].stateMachine.AddState("S0");
+        sourceLayers[1].stateMachine.AddState("S1");
+        source.layers = sourceLayers;
+
+        typeof(VRC3CVRCore).GetMethod("MergeVrcAnimatorIntoChilloutAnimator", Flags)
+            .Invoke(core, new object[] { source, animatorID });
+
+        var merged = target.layers;
+        Assert.AreEqual(2, merged.Length);
+        Assert.AreEqual(expected, merged[0].blendingMode);
+        Assert.AreEqual(expected, merged[1].blendingMode,
+            "every layer of the Additive playable is additive once merged, not just the first");
+
+        Object.DestroyImmediate(source);
+        Object.DestroyImmediate(target);
+    }
+
     [Test]
     public void ReplaceVRCMask_ReplacesBuiltInVrcMaskNamesWithCckEquivalentsAndPassesOthersThrough()
     {

--- a/Tests/Editor/VRC3CVRBehaviourConversionTests.cs
+++ b/Tests/Editor/VRC3CVRBehaviourConversionTests.cs
@@ -521,9 +521,6 @@ public class VRC3CVRBehaviourConversionTests
     [Test]
     public void GetAvatarMaskForLayer_AdditiveFirstLayer_IgnoresTheLayerMask()
     {
-        // VRChat ignores the Additive playable's first layer mask, so the avatar was authored with
-        // that mask having no effect. Honouring it here would apply a restriction the author never
-        // experienced.
         var core = new VRC3CVRCore();
         SetPrivateField(core, "fullMask", MakeMask("Full", AvatarMaskBodyPart.LeftArm, AvatarMaskBodyPart.RightArm));
         SetPrivateField(core, "musclesOnlyMask", MakeMask("Muscles"));
@@ -535,7 +532,7 @@ public class VRC3CVRBehaviourConversionTests
 
         Assert.IsTrue(result.GetHumanoidBodyPartActive(AvatarMaskBodyPart.LeftArm));
         Assert.IsTrue(result.GetHumanoidBodyPartActive(AvatarMaskBodyPart.RightArm),
-            "the layer mask excluded RightArm, but VRChat never applied it");
+            "the first layer's mask must not narrow the result");
     }
 
     [Test]

--- a/Tests/Editor/VRC3CVRBehaviourConversionTests.cs
+++ b/Tests/Editor/VRC3CVRBehaviourConversionTests.cs
@@ -501,9 +501,8 @@ public class VRC3CVRBehaviourConversionTests
             "restriction on either input mask is silently dropped from the combined mask.");
     }
 
-    [TestCase(VRC3CVRCore.VRCBaseAnimatorID.BASE)]
-    [TestCase(VRC3CVRCore.VRCBaseAnimatorID.ADDITIVE)]
-    public void GetAvatarMaskForLayer_BaseAndAdditive_IntersectWithFullMask(VRC3CVRCore.VRCBaseAnimatorID animatorID)
+    [Test]
+    public void GetAvatarMaskForLayer_Base_IntersectsWithFullMask()
     {
         var core = new VRC3CVRCore();
         SetPrivateField(core, "fullMask", MakeMask("Full", AvatarMaskBodyPart.LeftArm, AvatarMaskBodyPart.RightArm));
@@ -512,9 +511,46 @@ public class VRC3CVRBehaviourConversionTests
 
         var layerMask = MakeMask("Layer", AvatarMaskBodyPart.LeftArm, AvatarMaskBodyPart.Head);
 
-        var result = InvokeGetAvatarMaskForLayerAndVRCAnimator(core, animatorID, 0, layerMask);
+        var result = InvokeGetAvatarMaskForLayerAndVRCAnimator(core, VRC3CVRCore.VRCBaseAnimatorID.BASE, 0, layerMask);
 
         Assert.IsTrue(result.GetHumanoidBodyPartActive(AvatarMaskBodyPart.LeftArm), "active in both full mask and layer mask");
+        Assert.IsFalse(result.GetHumanoidBodyPartActive(AvatarMaskBodyPart.RightArm), "layer mask excluded RightArm");
+        Assert.IsFalse(result.GetHumanoidBodyPartActive(AvatarMaskBodyPart.Head), "full mask excluded Head");
+    }
+
+    [Test]
+    public void GetAvatarMaskForLayer_AdditiveFirstLayer_IgnoresTheLayerMask()
+    {
+        // VRChat ignores the Additive playable's first layer mask, so the avatar was authored with
+        // that mask having no effect. Honouring it here would apply a restriction the author never
+        // experienced.
+        var core = new VRC3CVRCore();
+        SetPrivateField(core, "fullMask", MakeMask("Full", AvatarMaskBodyPart.LeftArm, AvatarMaskBodyPart.RightArm));
+        SetPrivateField(core, "musclesOnlyMask", MakeMask("Muscles"));
+        SetPrivateField(core, "emptyMask", MakeMask("Empty"));
+
+        var layerMask = MakeMask("Layer", AvatarMaskBodyPart.LeftArm);
+
+        var result = InvokeGetAvatarMaskForLayerAndVRCAnimator(core, VRC3CVRCore.VRCBaseAnimatorID.ADDITIVE, 0, layerMask);
+
+        Assert.IsTrue(result.GetHumanoidBodyPartActive(AvatarMaskBodyPart.LeftArm));
+        Assert.IsTrue(result.GetHumanoidBodyPartActive(AvatarMaskBodyPart.RightArm),
+            "the layer mask excluded RightArm, but VRChat never applied it");
+    }
+
+    [Test]
+    public void GetAvatarMaskForLayer_AdditiveLaterLayer_IntersectsWithFullMask()
+    {
+        var core = new VRC3CVRCore();
+        SetPrivateField(core, "fullMask", MakeMask("Full", AvatarMaskBodyPart.LeftArm, AvatarMaskBodyPart.RightArm));
+        SetPrivateField(core, "musclesOnlyMask", MakeMask("Muscles"));
+        SetPrivateField(core, "emptyMask", MakeMask("Empty"));
+
+        var layerMask = MakeMask("Layer", AvatarMaskBodyPart.LeftArm, AvatarMaskBodyPart.Head);
+
+        var result = InvokeGetAvatarMaskForLayerAndVRCAnimator(core, VRC3CVRCore.VRCBaseAnimatorID.ADDITIVE, 1, layerMask);
+
+        Assert.IsTrue(result.GetHumanoidBodyPartActive(AvatarMaskBodyPart.LeftArm));
         Assert.IsFalse(result.GetHumanoidBodyPartActive(AvatarMaskBodyPart.RightArm), "layer mask excluded RightArm");
         Assert.IsFalse(result.GetHumanoidBodyPartActive(AvatarMaskBodyPart.Head), "full mask excluded Head");
     }

--- a/Tests/Editor/VRC3CVRBehaviourConversionTests.cs
+++ b/Tests/Editor/VRC3CVRBehaviourConversionTests.cs
@@ -622,8 +622,6 @@ public class VRC3CVRBehaviourConversionTests
         var target = new AnimatorController { name = "target" };
         SetPrivateField(core, "chilloutAnimatorController", target);
 
-        // an author's Additive controller normally leaves its layers on Override — the platform,
-        // not the controller, is what makes the playable additive
         var source = new AnimatorController { name = "source" };
         source.AddLayer("L0");
         source.AddLayer("L1");


### PR DESCRIPTION
VRChat の Additive playable には、コントローラのアセットにはどこにも書かれていない2つの規則がある。変換はそのどちらも再現していなかった。

設計の全体は #28 の §2「Additive の扱い」にある。

## ① 加算になっていなかった

> "The Additive layer is special because it is _always_ set to 'Additive' blending."
> — [Playable Layers](https://creators.vrchat.com/avatars/playable-layers/)

**プラットフォームが強制する規則で、コントローラ側の値ではない。** そのためアバター作者の Additive コントローラは、レイヤーを `Override` のまま置いているのが普通である。

変換は `blendingMode` をソースからそのままコピーしていたので、それが weight 1 の `Override` として合流していた。呼吸のような加算モーションが、体のポーズに**足される**のではなく**置き換える**。`convertAdditiveLayer` が既定 false なので露出は限定的だったが、有効にすると壊れる。

Additive playable 由来のレイヤーは全部 `Additive` にする。第0レイヤーだけでない理由: 1枚でも `Override` のまま残ると、そのレイヤーが**マージ後のポーズ全体**を置き換えてしまう。全部加算にした場合の副作用は、複数レイヤーを持つ Additive コントローラで寄与が重複しうることだが、こちらは壊れ方が明らかに軽い（大半の Additive playable は1レイヤーしか持たない）。

## ② 効いていないはずのマスクが効いていた

> "**Additive First Layer Avatar Mask Ignored** - The first layer (base layer, 0th layer, etc)'s Avatar Mask is ignored. This is for internal masking purposes."

第0レイヤーのマスクは VRChat では**無視される**ので、アバターはそのマスクが効いていない状態で作られている。マージすると第0レイヤーでなくなった瞬間に効き始め、作者が経験したことのない制限がかかる。

weight にも同じ「第0レイヤー特例」があり（Unity が実行時 weight を 1 に強制する）、そちらは既に対応済み。**playable ごとに第0レイヤーの意味論が違う**というのが VRChat の設計で、変換器はそれを playable 単位で持つ必要がある。FX の「空マスク → マッスル全無効の既定マスク生成」も同種の特例で、これも実装済み。

## テスト

EditMode 143 件が緑。新規4件:

- Additive 第0レイヤーがソースマスクを無視すること
- Additive 第1レイヤー以降は従来どおり交差すること
- Additive playable のレイヤーが**全部** `Additive` になること
- FX が `Override` のままであること（対照）

既存の `GetAvatarMaskForLayer_BaseAndAdditive_IntersectWithFullMask` は BASE と ADDITIVE を1つの `TestCase` で束ねて layerID 0 の交差を期待していた。ADDITIVE の第0レイヤーは交差してはいけなくなったので束ねを解き、BASE 側のカバレッジはそのまま別テストに移してある。

## 実機検証を付けていない理由

加算ブレンドは **Unity のアニメーションシステムそのもの**の挙動で、ChilloutVR は再実装していない。#29（速度の座標系）で実機検証が必要だったのは、そちらがクライアント固有のパラメータ意味論に依存していて、実測でしか分からなかったからである。ここでは変換が正しいレイヤーを組めているかだけが問題で、それは EditMode テストが直接証明している。

なお、判定できる in-game fixture を組むこと自体は可能だが素直ではない。Unity の加算ブレンドは「クリップの第1フレームからの差分」なので定数クリップは何も寄与せず、また `Override` と `Additive` で差が出るのは上下のレイヤーが**同じプロパティ**を animate している場合に限られる。この2条件を満たす fixture が必要になる。必要と判断されれば別途組む。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
