### PR TITLE
time the tests and the conversion, and let a run be filtered

### DIFF
--- a/Editor/VRC3CVRCore.cs
+++ b/Editor/VRC3CVRCore.cs
@@ -16,6 +16,7 @@ using ABI.CCK.Scripts;
 using VRC.SDK3.Dynamics.Contact.Components;
 using VRC.SDK3.Dynamics.Constraint.Components;
 using VRCConstraintBase = VRC.Dynamics.VRCConstraintBase;
+using Stopwatch = System.Diagnostics.Stopwatch;
 
 [Serializable]
 public class VRC3CVRCore : VRC3CVRConvertConfig
@@ -134,6 +135,9 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
         {
             Debug.Log("Starting to convert...");
 
+            var totalStopwatch = Stopwatch.StartNew();
+
+            var setupStopwatch = Stopwatch.StartNew();
             AssetDatabase.Refresh();
 
             // Generate Combined hand animations
@@ -148,13 +152,21 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
             emptyMask = LoadMask("vrc3cvrEmptyMask.mask");
             fullMask = LoadMask("vrc3cvrFullMask.mask");
             musclesOnlyMask = LoadMask("vrc3cvrMusclesOnly.mask");
+            setupStopwatch.Stop();
 
+            var cloneStopwatch = Stopwatch.StartNew();
             CreateChilloutAvatar();
             GetValuesFromVrcAvatar();
             CreateChilloutComponentIfNeeded();
             PopulateChilloutComponent();
+            cloneStopwatch.Stop();
+
+            var mergeStopwatch = Stopwatch.StartNew();
             CreateEmptyChilloutAnimator();
             MergeVrcAnimatorsIntoChilloutAnimator();
+            mergeStopwatch.Stop();
+
+            var contactsStopwatch = Stopwatch.StartNew();
             contactReceiverParameters = new HashSet<string>();
             if (convertVRCContactSendersAndReceivers)
             {
@@ -173,6 +185,9 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
                 ConvertVrcConstraintsToUnityConstraints();
                 RemapAnimationOfConstraintComponent();
             }
+            contactsStopwatch.Stop();
+
+            var parametersStopwatch = Stopwatch.StartNew();
             SetAnimator();
             ConvertVrcParametersToChillout();
             SetNonZeroDefaultValueParameters();
@@ -187,7 +202,9 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
             MakeUprightFeedLayer();
             MakeGameStateParameterStreams();
             InsertChilloutOverride();
+            parametersStopwatch.Stop();
 
+            var componentsStopwatch = Stopwatch.StartNew();
             ConvertVrcComponents();
             if (shouldDeleteVRCAvatarDescriptorAndPipelineManager)
             {
@@ -198,19 +215,25 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
             {
                 HideOriginalAvatar();
             }
+            componentsStopwatch.Stop();
 
+            var saveStopwatch = Stopwatch.StartNew();
             if (saveAssets)
             {
                 SaveChilloutAnimator();
                 SaveChilloutOverride();
             }
+            saveStopwatch.Stop();
 
             // Clear the cache
             avatarMaskCombineCache = new Dictionary<(AvatarMask, AvatarMask), AvatarMask>();
             gestureMask = null;
             generatedLayerNames = new HashSet<string>();
 
+            totalStopwatch.Stop();
+
             Debug.Log("Conversion complete!");
+            Debug.Log($"VRC3CVR: convert timings setup={setupStopwatch.Elapsed.TotalSeconds:0.000}s clone={cloneStopwatch.Elapsed.TotalSeconds:0.000}s merge={mergeStopwatch.Elapsed.TotalSeconds:0.000}s contacts={contactsStopwatch.Elapsed.TotalSeconds:0.000}s parameters={parametersStopwatch.Elapsed.TotalSeconds:0.000}s components={componentsStopwatch.Elapsed.TotalSeconds:0.000}s save={saveStopwatch.Elapsed.TotalSeconds:0.000}s total={totalStopwatch.Elapsed.TotalSeconds:0.000}s");
         }
         finally
         {


### PR DESCRIPTION
issue #33 Phase 0(計測)。

- `VRC3CVRCore.Convert()` にフェーズ毎 Stopwatch(setup/clone/merge/contacts/parameters/components/save + total)を追加し、完了時に1行サマリを Debug.Log。挙動変更ゼロ(レビューで文単位の等価を確認済み)
- フィルタ付きテストランナーとテスト毎 duration 出力は規約どおり Unity プロジェクト側の repro スクラッチ(`Assets/VRC3CVR_TempRepro/`、リポジトリ外)に実装

計測結果は issue #33 に記録。全スイート 170 passed / 0 failed(master ベースライン一致)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)