### PR TITLE
line the dropdown options up with the values they write

### DIFF
--- a/Editor/VRC3CVRCore.cs
+++ b/Editor/VRC3CVRCore.cs
@@ -670,13 +670,29 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
                         }
                         else
                         {
-                            // control.value (and therefore the key here) can be negative; start the
-                            // range at the lowest key instead of assuming it is always 0, or negative
-                            // options are silently dropped from the resulting dropdown.
-                            var firstIndex = (int)discreteIdTable.Keys.Min();
+                            // CVR dropdown options have no per-option value field: the option's list
+                            // index is the parameter value it sets (AddCondition(Equals, i, ...) in
+                            // CVRAdvancedAvatarSettings, built from CCK_CVRAvatarEditor's
+                            // AdvSettings_Dropdown). The list must therefore start at index 0. VRC
+                            // control.value can be negative, but there is no index that could stand in
+                            // for a negative value, so such options are dropped rather than shifting
+                            // the whole list to make room for them.
+                            var negativeKeys = discreteIdTable.Keys.Where(k => k < 0).ToList();
+                            if (negativeKeys.Count > 0)
+                            {
+                                Debug.LogWarning($"Param \"{vrcParam.name}\" has option value(s) {string.Join(", ", negativeKeys)} which are negative; CVR dropdown options are addressed by list index and can't represent a negative value, so those option(s) are dropped.");
+                                discreteIdTable = discreteIdTable.Where(p => p.Key >= 0).ToDictionary(p => p.Key, p => p.Value);
+                            }
+
+                            if (discreteIdTable.Count == 0)
+                            {
+                                Debug.LogWarning($"Int parameter \"{vrcParam.name}\" had only negative option values, so no CVR menu entry is generated for it (the animator parameter itself is still converted).");
+                                break;
+                            }
+
                             var lastIndex = (int)discreteIdTable.Keys.Max();
                             var menuEntryNames = new List<string>();
-                            for (var j = firstIndex; j < lastIndex + 1; j++)
+                            for (var j = 0; j <= lastIndex; j++)
                             {
                                 menuEntryNames.Add(discreteIdTable.TryGetValue(j, out var menuEntry) ? menuEntry.name : "---");
                             }

--- a/Tests/Editor/VRC3CVRMenuConversionTests.cs
+++ b/Tests/Editor/VRC3CVRMenuConversionTests.cs
@@ -3,11 +3,13 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Text.RegularExpressions;
 using ABI.CCK.Components;
 using ABI.CCK.Scripts;
 using NUnit.Framework;
 using UnityEditor.Animations;
 using UnityEngine;
+using UnityEngine.TestTools;
 using VRC.SDK3.Avatars.Components;
 using VRC.SDK3.Avatars.ScriptableObjects;
 
@@ -425,26 +427,50 @@ public class VRC3CVRMenuConversionTests
     }
 
     [Test]
-    public void Bug_NegativeToggleValue_IsSilentlyDroppedFromDropdown()
+    public void NegativeToggleValue_IsDroppedWithWarning()
     {
-        // REAL BUG: FindMenuButtonsAndToggles stores toggle entries keyed by the raw VRC
-        // control.value, which can be negative, but ConvertVrcParametersToChillout's Int branch
-        // only walks `for (j = 0; j < lastIndex + 1; j++)` starting at zero. A control with a
-        // negative value is therefore silently omitted from the resulting dropdown instead of
-        // being clamped, reordered, or reported.
+        // CVR dropdown options carry no per-option value field -- the option's list index is the
+        // value it sets (AddCondition(Equals, i, ...) in CVRAdvancedAvatarSettings) -- so there is
+        // no index that could stand in for a negative control.value. It is dropped, with a warning,
+        // rather than shifting the whole option list to make room for it.
         core.useHierarchicalDropdownMenuName = false; // isolate from the flat-menu naming bug below
         SetMenu(Menu(
             Toggle("Negative", "Mode", -1f),
             Toggle("Zero", "Mode", 0f),
             Toggle("One", "Mode", 1f)));
-        SetParams(Param("Mode", VRCExpressionParameters.ValueType.Int, defaultValue: -1f));
+        SetParams(Param("Mode", VRCExpressionParameters.ValueType.Int, defaultValue: 0f));
+
+        LogAssert.Expect(LogType.Warning, new Regex(Regex.Escape(
+            "Param \"Mode\" has option value(s) -1 which are negative; CVR dropdown options are "
+                + "addressed by list index and can't represent a negative value, so those option(s) are dropped.")));
 
         Convert();
 
         var dropdown = (CVRAdvancesAvatarSettingGameObjectDropdown)Settings[0].setting;
-        // Correct behavior would keep all three options in control order; today "Negative" vanishes
-        // because the option-building loop starts at index 0.
-        Assert.AreEqual(new[] { "Negative", "Zero", "One" }, dropdown.options.Select(o => o.name).ToArray());
+        Assert.AreEqual(new[] { "Zero", "One" }, dropdown.options.Select(o => o.name).ToArray());
+        Assert.AreEqual(0, dropdown.defaultValue);
+    }
+
+    [Test]
+    public void IntDropdown_OptionValuesStartAtOne_KeepsZeroOriginIndexAlignment()
+    {
+        // Regression for the option-list-shift bug: menus that never assign value 0 to any option
+        // (VRChat's own emote menu, and NEmote-style custom menus, both start at 1 since 0 means
+        // "no selection") used to have their option list start at the lowest key present -- shifting
+        // every option's list index, and therefore its CVR value, down by one. The list must instead
+        // start at index 0, with a "---" placeholder standing in for the unused value 0.
+        var subMenu = Menu(
+            Toggle("First", "Emote", 1f),
+            Toggle("Second", "Emote", 2f),
+            Toggle("Third", "Emote", 3f));
+        SetMenu(Menu(SubMenuControl("Emotes", subMenu)));
+        SetParams(Param("Emote", VRCExpressionParameters.ValueType.Int, defaultValue: 1f));
+
+        Convert();
+
+        var dropdown = (CVRAdvancesAvatarSettingGameObjectDropdown)Settings[0].setting;
+        Assert.AreEqual(new[] { "---", "First", "Second", "Third" }, dropdown.options.Select(o => o.name).ToArray());
+        Assert.AreEqual(1, dropdown.defaultValue);
     }
 
     [Test]


### PR DESCRIPTION
## 問題

ChilloutVR の Advanced Settings ドロップダウンは「選択肢の並び順(index)がそのままパラメータ値」という仕様(選択肢ごとの値指定は存在しない)。一方 vrc3cvr の変換はコミット bbb5adf 以降、選択肢リストを最小値起点で構築していたため、値 1..N(0 = 選択なしで項目なし)の VRC メニューでは全項目が -1 ズレていた。実例: NEmote の 52 エモートメニューで「2番を選ぶと1番が再生される」(ユーザー実機確認)。

## 修正

- 選択肢リストを 0 起点に戻し、欠番は "---" で埋める(index = 値 が復元され、既定値とも整合)
- 負値のトグルは CVR のドロップダウンでは表現不可能なため、警告を出して除外(bbb5adf が守ろうとした対象だが、起点シフトでは元々救えていなかった)
- 誤った契約を固定していたテストを新契約(負値は警告つき除外)に書き換え、値 1..N ケースの回帰テストを追加

## Test plan

171 passed / 0 failed(master 170 + 回帰1本)。新回帰テストは修正前コードで RED を確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)