### PR TITLE
TrackingType を供給する

### DIFF
--- a/Editor/VRC3CVRCore.cs
+++ b/Editor/VRC3CVRCore.cs
@@ -186,6 +186,8 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
             // reading it, and this is what declares VRMode, without which they emit no DeviceMode
             // entry at all -- and an unfed VRMode reads 0, silently discretising Upright in VR.
             MakeUprightFeedLayer();
+            // Before the streams too: this is what declares the full body flag they route
+            MakeTrackingTypeFeedLayer();
             MakeGameStateParameterStreams();
             InsertChilloutOverride();
 
@@ -938,6 +940,9 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
         // an avatar whose locomotion replaced CVR's derives Upright rather than receiving it, so it
         // stops being a synced input and becomes a driven local value (MakeUprightFeedLayer, same guard)
         if (feedGameStateParameters && vrcBaseReplacesCckLocomotion) preserveParameters.Remove("Upright");
+        // likewise TrackingType, which every client derives from the synced flag instead of receiving
+        // (MakeTrackingTypeFeedLayer)
+        if (feedGameStateParameters) preserveParameters.Remove("TrackingType");
         if (!addActionMenuModAnnotations)
         {
             impulseParameters = new HashSet<string>();
@@ -5391,6 +5396,24 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
         });
     }
 
+    static AnimatorDriverTask DriverTask(AnimatorControllerParameter[] declared, AnimatorDriverTask.Operator op,
+        string target, AnimatorDriverTask.ParameterType targetType, string a, string b, float bValue)
+    {
+        return new AnimatorDriverTask
+        {
+            op = op,
+            targetName = target,
+            targetType = targetType,
+            aType = AnimatorDriverTask.SourceType.Parameter,
+            aParamType = AnimatorDriverParameterType(declared, a),
+            aName = a,
+            bType = b == null ? AnimatorDriverTask.SourceType.Static : AnimatorDriverTask.SourceType.Parameter,
+            bParamType = b == null ? AnimatorDriverTask.ParameterType.Float : AnimatorDriverParameterType(declared, b),
+            bName = b ?? "",
+            bValue = bValue,
+        };
+    }
+
     const string UprightSensorParameter = "UprightSensor";
 
     // Set while Upright is computed by the layer below instead of received from the client.
@@ -5444,22 +5467,8 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
         chilloutAnimatorController.parameters = parameters;
 
         var declared = chilloutAnimatorController.parameters;
-        AnimatorDriverTask Task(AnimatorDriverTask.Operator op, string target, string a, string b, float bValue = 0f)
-        {
-            return new AnimatorDriverTask
-            {
-                op = op,
-                targetName = target,
-                targetType = AnimatorDriverTask.ParameterType.Float,
-                aType = AnimatorDriverTask.SourceType.Parameter,
-                aParamType = AnimatorDriverParameterType(declared, a),
-                aName = a,
-                bType = b == null ? AnimatorDriverTask.SourceType.Static : AnimatorDriverTask.SourceType.Parameter,
-                bParamType = b == null ? AnimatorDriverTask.ParameterType.Float : AnimatorDriverParameterType(declared, b),
-                bName = b ?? "",
-                bValue = bValue,
-            };
-        }
+        AnimatorDriverTask Task(AnimatorDriverTask.Operator op, string target, string a, string b, float bValue = 0f) =>
+            DriverTask(declared, op, target, AnimatorDriverTask.ParameterType.Float, a, b, bValue);
 
         var tickClip = new AnimationClip { name = "VRC3CVR_UprightTick" };
         tickClip.SetCurve("", typeof(Animator), NonSyncParameterName("UprightTick"), AnimationCurve.Constant(0f, 1f / 60f, 0f));
@@ -5532,6 +5541,95 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
             },
         });
         uprightIsDerived = true;
+    }
+
+    const string FullBodyParameter = "TrackingTypeFullBody";
+
+    // VRChat's TrackingType counts the wearer's tracked points; ChilloutVR reports only whether full
+    // body is on, which leaves two values a converted humanoid can honestly report. 3 covers both
+    // head-and-hands VR and desktop -- VRChat gives desktop humanoids 3 as well, and has the avatar
+    // tell the two apart by VRMode -- and 6 covers full body. The 4 and 5 of a hip-only or feet-only
+    // rig are indistinguishable from 6 behind a single flag, and 1 belongs to generic rigs.
+    //
+    // The flag is what gets synced and every client derives the number from it, so a remote copy
+    // costs a bool rather than TrackingType's int (see MakeGameStateParameterStreams).
+    void MakeTrackingTypeFeedLayer()
+    {
+        var trackingType = NonSyncParameterName("TrackingType");
+        var parameters = chilloutAnimatorController.parameters;
+        if (!feedGameStateParameters || !parameters.Any(p => p.name == trackingType))
+        {
+            return;
+        }
+        if (!parameters.Any(p => p.name == FullBodyParameter))
+        {
+            ArrayUtility.Add(ref parameters, new AnimatorControllerParameter
+            {
+                name = FullBodyParameter,
+                type = AnimatorControllerParameterType.Bool,
+            });
+            chilloutAnimatorController.parameters = parameters;
+        }
+
+        var declared = chilloutAnimatorController.parameters;
+        var targetType = AnimatorDriverParameterType(declared, trackingType);
+        var tickClip = new AnimationClip { name = "VRC3CVR_TrackingTypeTick" };
+        tickClip.SetCurve("", typeof(Animator), NonSyncParameterName("TrackingTypeTick"), AnimationCurve.Constant(0f, 1f / 60f, 0f));
+        var recomputeState = new AnimatorState
+        {
+            hideFlags = HideFlags.HideInHierarchy,
+            name = "Recompute",
+            writeDefaultValues = false,
+            motion = tickClip,
+            behaviours = new StateMachineBehaviour[]
+            {
+                new AnimatorDriver
+                {
+                    hideFlags = HideFlags.HideInHierarchy,
+                    localOnly = false,
+                    EnterTasks = new List<AnimatorDriverTask>
+                    {
+                        // 3 + 3 * FullBody
+                        DriverTask(declared, AnimatorDriverTask.Operator.Multiplication, trackingType, targetType, FullBodyParameter, null, 3f),
+                        DriverTask(declared, AnimatorDriverTask.Operator.Addition, trackingType, targetType, trackingType, null, 3f),
+                    },
+                },
+            },
+        };
+        recomputeState.transitions = new AnimatorStateTransition[]
+        {
+            new AnimatorStateTransition
+            {
+                hideFlags = HideFlags.HideInHierarchy,
+                hasExitTime = true,
+                exitTime = 1f,
+                hasFixedDuration = true,
+                duration = 0f,
+                offset = 0f,
+                destinationState = recomputeState,
+            },
+        };
+        var layerName = chilloutAnimatorController.MakeUniqueLayerName("VRC3CVR_TrackingType");
+        AddGeneratedLayer(new AnimatorControllerLayer
+        {
+            name = layerName,
+            defaultWeight = 1f,
+            blendingMode = AnimatorLayerBlendingMode.Override,
+            avatarMask = emptyMask,
+            stateMachine = new AnimatorStateMachine
+            {
+                hideFlags = HideFlags.HideInHierarchy,
+                name = layerName,
+                entryPosition = new Vector3(0, -100),
+                exitPosition = new Vector3(0, 200),
+                anyStatePosition = new Vector3(0, -300),
+                defaultState = recomputeState,
+                states = new ChildAnimatorState[]
+                {
+                    new ChildAnimatorState { state = recomputeState, position = new Vector3(0, 0) },
+                },
+            },
+        });
     }
 
     const string VrcEmoteCompatLayerName = "VRC3CVR_VRCEmoteCompat";
@@ -5722,15 +5820,17 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
 
     // VRChat built-ins that ChilloutVR does not supply to the animator. The client's parameter
     // stream provides equivalent sources; each stream type's semantics were verified against the
-    // decompiled client (DeviceMode: isUsingVr ? 1 : 0, matching VRMode).
+    // decompiled client (DeviceMode: isUsingVr ? 1 : 0, matching VRMode). The last entry is not a
+    // VRChat name: it is the input the derived TrackingType is built from (MakeTrackingTypeFeedLayer).
     static readonly (string parameterName, CVRParameterStreamEntry.Type streamType)[] GameStateParameterStreams =
     {
         ("MuteSelf", CVRParameterStreamEntry.Type.LocalPlayerMuted),
         ("VRMode", CVRParameterStreamEntry.Type.DeviceMode),
         ("Upright", CVRParameterStreamEntry.Type.AvatarUpright),
+        (FullBodyParameter, CVRParameterStreamEntry.Type.LocalPlayerFullBodyEnabled),
     };
 
-    // Feed MuteSelf/VRMode/Upright on the wearer's client via CVRParameterStream; the parameters
+    // Feed the parameters above on the wearer's client via CVRParameterStream; the parameters
     // are kept synced (AdjustParameterNames) so remotes receive the values through CVR's normal
     // parameter sync. Runs after AdjustParameterNames so parameter names are final.
     void MakeGameStateParameterStreams()

--- a/Tests/Editor/VRC3CVRGestureConversionTests.cs
+++ b/Tests/Editor/VRC3CVRGestureConversionTests.cs
@@ -477,5 +477,89 @@ public class VRC3CVRGestureConversionTests
             if (controllerUnused != null) Object.DestroyImmediate(controllerUnused);
         }
     }
+
+    // ---- the derived TrackingType ----
+
+    static VRC3CVRCore MakeTrackingTypeCore(AnimatorController controller, GameObject avatar)
+    {
+        var core = MakeStreamCore(controller, avatar);
+        typeof(VRC3CVRCore).GetField("generatedLayerNames", Flags).SetValue(core, new System.Collections.Generic.HashSet<string>());
+        typeof(VRC3CVRCore).GetMethod("MakeTrackingTypeFeedLayer", Flags).Invoke(core, null);
+        return core;
+    }
+
+    [Test]
+    public void TrackingTypeFeedLayer_DerivesThreeAndSixFromTheSyncedFlag()
+    {
+        AnimatorController controller = null;
+        GameObject avatar = null;
+        try
+        {
+            controller = new AnimatorController { name = "trackingTypeTest" };
+            avatar = new GameObject("TrackingTypeTestAvatar");
+            controller.AddParameter("#TrackingType", AnimatorControllerParameterType.Int);
+            var core = MakeTrackingTypeCore(controller, avatar);
+
+            var flag = controller.parameters.Single(p => p.name == "TrackingTypeFullBody");
+            Assert.AreEqual(AnimatorControllerParameterType.Bool, flag.type, "a bool is what makes this cheaper than syncing the int");
+            var driver = (ABI.CCK.Components.AnimatorDriver)controller.layers
+                .Single(l => l.name.StartsWith("VRC3CVR_TrackingType"))
+                .stateMachine.states.Single().state.behaviours.Single();
+            Assert.IsFalse(driver.localOnly, "a remote copy has to derive the same value the wearer does");
+
+            // run the tasks the way the client would, so the constants are checked by the numbers
+            // they produce: head and hands (which is also desktop) is 3, full body is 6
+            float Derive(float fullBody)
+            {
+                var values = new System.Collections.Generic.Dictionary<string, float>
+                {
+                    { "TrackingTypeFullBody", fullBody }, { "#TrackingType", 0f },
+                };
+                foreach (var task in driver.EnterTasks)
+                {
+                    var a = values[task.aName];
+                    values[task.targetName] =
+                        task.op == ABI.CCK.Components.AnimatorDriverTask.Operator.Multiplication
+                            ? a * task.bValue
+                            : a + task.bValue;
+                }
+                return values["#TrackingType"];
+            }
+            Assert.AreEqual(3f, Derive(0f));
+            Assert.AreEqual(6f, Derive(1f));
+
+            typeof(VRC3CVRCore).GetMethod("MakeGameStateParameterStreams", Flags).Invoke(core, null);
+            Assert.AreEqual(
+                new[] { "LocalPlayerFullBodyEnabled -> TrackingTypeFullBody" },
+                avatar.GetComponent<ABI.CCK.Components.CVRParameterStream>().entries
+                    .Select(e => e.type + " -> " + e.parameterName).ToArray());
+        }
+        finally
+        {
+            if (avatar != null) Object.DestroyImmediate(avatar);
+            if (controller != null) Object.DestroyImmediate(controller);
+        }
+    }
+
+    [Test]
+    public void TrackingTypeFeedLayer_SkippedWhenParameterUnused()
+    {
+        AnimatorController controller = null;
+        GameObject avatar = null;
+        try
+        {
+            controller = new AnimatorController { name = "trackingTypeTest" };
+            avatar = new GameObject("TrackingTypeTestAvatar");
+            MakeTrackingTypeCore(controller, avatar);
+
+            Assert.AreEqual(0, controller.layers.Length);
+            Assert.IsEmpty(controller.parameters, "the flag costs sync, so an avatar that ignores TrackingType must not get one");
+        }
+        finally
+        {
+            if (avatar != null) Object.DestroyImmediate(avatar);
+            if (controller != null) Object.DestroyImmediate(controller);
+        }
+    }
 }
 #endif


### PR DESCRIPTION
#41 のうち、導出とリモート同期（1 と 3）。

## 何をしたか

`TrackingType` を読むアバターに対して、供給レイヤー（`MakeTrackingTypeFeedLayer`）を 1 枚生成する。読んでいなければ何も生成しない。

導出は `LocalPlayerFullBodyEnabled` だけから:

| 条件 | TrackingType |
|---|---|
| デスクトップ / VR・FBT 無効 | 3 |
| VR・FBT 有効 | 6 |

issue の表はデスクトップを 1 としていたが、[VRChat のドキュメント](https://creators.vrchat.com/avatars/animator-parameters#trackingtype-parameter)では 1 は Generic リグの値で、デスクトップの humanoid は **3** を読む（3 は「head and hands」で、VR の 3 点かデスクトップかは `VRMode` で区別する、と明記されている）。したがって `DeviceMode` は導出に要らない。4（腰のみ）と 5（足のみ）はフラグ 1 本では 6 と区別できない。

同期は、導出結果の int ではなく入力のフラグ（新規 Bool `TrackingTypeFullBody`、`CVRParameterStream` 経由）を送り、各クライアントが同じ数値を導出する（`AnimatorDriver.localOnly = false`）。`UprightSensor` と同じ形。

## やっていないこと

- #41 の 4（6 点時の locomotion 抑制）と「関連して見直すもの」の 2 件 — どれも実機計測が要る
- 実機での値の突き合わせ。導出は上記ドキュメント準拠で、CVR 実機では未確認

## テスト

`VRC3CVRGestureConversionTests` 25 件パス（新規 2 件: 導出値 3/6 と、未使用時にフラグを増やさないこと）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
