### PR TITLE
エモート中に手のジェスチャーを止める

### DIFF
--- a/Editor/VRC3CVRCore.cs
+++ b/Editor/VRC3CVRCore.cs
@@ -3894,6 +3894,34 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
         }
     }
 
+    static readonly string[] CckHandLayerNames = { "LeftHand", "RightHand" };
+
+    // ChilloutVR mutes the hands for the length of an emote by layer name -- SetLayerWeight on
+    // "LeftHand" and "RightHand" -- and its own layers under those names are the ones the Gesture
+    // playable displaces. VRChat's are named with a space in the middle, so the client's lookup
+    // finds nothing and a held gesture rides through the emote on the fingers, which is what
+    // neither platform does on its own.
+    //
+    // The client restores the layer to weight 1 when the emote ends rather than to what it found,
+    // so the name only goes to a layer that survives being handed over: one candidate for the side,
+    // weight already 1, and no layer of that name in the animator this merges into.
+    bool NameHandLayersForTheEmoteMute(AnimatorControllerLayer[] layers)
+    {
+        var renamed = false;
+        foreach (var cckName in CckHandLayerNames)
+        {
+            if (chilloutAnimatorController.layers.Any(existing => existing.name == cckName)) continue;
+            var candidates = layers.Where(layer => LettersAndDigits(layer.name) == LettersAndDigits(cckName)).ToArray();
+            if (candidates.Length != 1 || candidates[0].defaultWeight != 1f) continue;
+            candidates[0].name = cckName;
+            renamed = true;
+        }
+        return renamed;
+    }
+
+    static string LettersAndDigits(string name) =>
+        new string(name.Where(char.IsLetterOrDigit).ToArray()).ToLowerInvariant();
+
     void MergeVrcAnimatorIntoChilloutAnimator(AnimatorController originalAnimatorController, VRCBaseAnimatorID animatorID)
     {
         Debug.Log("Merging vrc animator \"" + originalAnimatorController.name + "\"...");
@@ -3950,6 +3978,10 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
                 controllerLayers[i] = layer;
                 layersModified = true;
             }
+        }
+        if (animatorID == VRCBaseAnimatorID.GESTURE && NameHandLayersForTheEmoteMute(controllerLayers))
+        {
+            layersModified = true;
         }
         // After the loop above, so the conditions this adds are already in CVR's own vocabulary
         // and must not go through ProcessStateMachine's VRChat-to-CVR adaptation.

--- a/Tests/Editor/VRC3CVRGestureConversionTests.cs
+++ b/Tests/Editor/VRC3CVRGestureConversionTests.cs
@@ -478,6 +478,54 @@ public class VRC3CVRGestureConversionTests
         }
     }
 
+    // ---- the hand layer names ChilloutVR mutes an emote with ----
+
+    static string[] NameHandLayers(AnimatorController destination, params AnimatorControllerLayer[] layers)
+    {
+        var core = new VRC3CVRCore();
+        typeof(VRC3CVRCore).GetField("chilloutAnimatorController", Flags).SetValue(core, destination);
+        typeof(VRC3CVRCore).GetMethod("NameHandLayersForTheEmoteMute", Flags).Invoke(core, new object[] { layers });
+        return layers.Select(layer => layer.name).ToArray();
+    }
+
+    static AnimatorControllerLayer Layer(string name, float weight = 1f)
+    {
+        return new AnimatorControllerLayer { name = name, defaultWeight = weight };
+    }
+
+    [Test]
+    public void HandLayers_TakeTheNameChilloutVrMutesThemBy_OnlyWhereTheRestoreIsHarmless()
+    {
+        var destination = new AnimatorController { name = "handLayerTest" };
+        try
+        {
+            // the stock gesture controller's names, which differ from CVR's by the space alone
+            Assert.AreEqual(
+                new[] { "LeftHand", "RightHand" },
+                NameHandLayers(destination, Layer("Left Hand"), Layer("Right Hand")));
+
+            // the client restores the layer to 1, so anything else is left where the avatar put it
+            Assert.AreEqual(
+                new[] { "Left Hand", "RightHand" },
+                NameHandLayers(destination, Layer("Left Hand", 0.5f), Layer("Right Hand")));
+
+            // one name cannot cover two layers
+            Assert.AreEqual(
+                new[] { "Left Hand", "left_hand", "RightHand" },
+                NameHandLayers(destination, Layer("Left Hand"), Layer("left_hand"), Layer("Right Hand")));
+
+            destination.AddLayer(new AnimatorControllerLayer { name = "LeftHand", defaultWeight = 1f });
+            Assert.AreEqual(
+                new[] { "Left Hand", "RightHand" },
+                NameHandLayers(destination, Layer("Left Hand"), Layer("Right Hand")),
+                "a layer already answering to the name keeps it");
+        }
+        finally
+        {
+            Object.DestroyImmediate(destination);
+        }
+    }
+
     // ---- the derived TrackingType ----
 
     static VRC3CVRCore MakeTrackingTypeCore(AnimatorController controller, GameObject avatar)


### PR DESCRIPTION
#50。ChilloutVR が探すレイヤー名を、Gesture playable から持ってきたレイヤーに渡す。

## やったこと

`MergeVrcAnimatorIntoChilloutAnimator` が Gesture playable をマージするとき、レイヤー名を `LeftHand` / `RightHand` に改名する（`NameHandLayersForTheEmoteMute`）。名前の一致は英数字だけを見るので、`Left Hand` も `left_hand` も拾う。

## 壊れるケースの除外

クライアントはエモート終了時に**元の値ではなく 1 を書き戻す**（`PlayerBase.LegacyEmoteCheck`）ので、渡して安全なレイヤーだけに渡す:

- その名前の候補が**片側ちょうど 1 枚**のとき（2 枚あればどちらに渡すか決められない）
- `defaultWeight` が**すでに 1** のとき（0.5 のレイヤーは、最初のエモート後に 1 に固定されてしまう）
- マージ先の animator に**同名のレイヤーがまだ無い**とき（CVR 自身の手レイヤーを残す設定では、そちらが名前を持ち続ける）

除外に当たったレイヤーは名前を変えず、現状のまま（＝エモート中もジェスチャーが残る）になる。

## テスト

`VRC3CVRGestureConversionTests` 26 件パス（新規 1 件: 標準名の改名と、除外 3 条件）。実機での確認はしていない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
