### PR TITLE
ChilloutVR が動かさないパラメータに定数を焼く

### DIFF
--- a/Editor/VRC3CVRCore.cs
+++ b/Editor/VRC3CVRCore.cs
@@ -879,16 +879,25 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
         { "IsOnFriendsList", "IsFriend" },
     };
 
-    static Dictionary<string, float> nonZeroDefaultValueMap = new Dictionary<string, float>
+    // What each of these declares is what the avatar reads for the whole session, so the value is
+    // written onto the declaration rather than left at whatever the VRChat animator carried: over
+    // there the client overwrites the declared value on the first frame, which lets an author leave
+    // anything at all in it, and here nothing does.
+    static Dictionary<string, float> platformAnswerDefaultValueMap = new Dictionary<string, float>
     {
         { "Grounded", 1f },
         // VRChat answers these from its own avatar scaling, which the wearer drives at runtime and
-        // ChilloutVR has no counterpart for, so they hold the unscaled reading for the whole
-        // session. ScaleModified and Earmuffs answer the same way at their own zero default.
+        // ChilloutVR has no counterpart for, so they hold the unscaled reading.
         { "ScaleFactor", 1f },
         { "ScaleFactorInverse", 1f },
+        { "ScaleModified", 0f },
+        // likewise a feature the platform does not have, so it is never on
+        { "Earmuffs", 0f },
         // "3 if the avatar was built using VRChat's SDK3 or later", which is the only input there is
         { "AvatarVersion", 3f },
+        // not derived from anything ChilloutVR reports, so the avatar reads the one value that is
+        // true of a player nobody is turning
+        { "AngularY", 0f },
         // zero is the prone band, so an unset Upright shows a frame of lying down on load
         { "Upright", 1f },
     };
@@ -4013,7 +4022,7 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
         // still a constant, for the same reason the scale parameters above are: nothing on this
         // platform moves it once the avatar is worn. VRChat states the percent against the scaling
         // limits it would have allowed, 0.2m to 5.0m.
-        var defaults = new Dictionary<string, float>(nonZeroDefaultValueMap)
+        var defaults = new Dictionary<string, float>(platformAnswerDefaultValueMap)
         {
             ["EyeHeightAsMeters"] = vrcViewPosition.y,
             ["EyeHeightAsPercent"] = Mathf.Clamp01((vrcViewPosition.y - 0.2f) / (5f - 0.2f)),

--- a/Editor/VRC3CVRCore.cs
+++ b/Editor/VRC3CVRCore.cs
@@ -882,9 +882,13 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
     static Dictionary<string, float> nonZeroDefaultValueMap = new Dictionary<string, float>
     {
         { "Grounded", 1f },
+        // VRChat answers these from its own avatar scaling, which the wearer drives at runtime and
+        // ChilloutVR has no counterpart for, so they hold the unscaled reading for the whole
+        // session. ScaleModified and Earmuffs answer the same way at their own zero default.
         { "ScaleFactor", 1f },
         { "ScaleFactorInverse", 1f },
-        { "EyeHeightAsPercent", 1f },
+        // "3 if the avatar was built using VRChat's SDK3 or later", which is the only input there is
+        { "AvatarVersion", 3f },
         // zero is the prone band, so an unset Upright shows a frame of lying down on load
         { "Upright", 1f },
     };
@@ -4005,10 +4009,19 @@ public class VRC3CVRCore : VRC3CVRConvertConfig
 
     void SetNonZeroDefaultValueParameters()
     {
+        // The eye height is the avatar's own, so it is not one value for every avatar -- but it is
+        // still a constant, for the same reason the scale parameters above are: nothing on this
+        // platform moves it once the avatar is worn. VRChat states the percent against the scaling
+        // limits it would have allowed, 0.2m to 5.0m.
+        var defaults = new Dictionary<string, float>(nonZeroDefaultValueMap)
+        {
+            ["EyeHeightAsMeters"] = vrcViewPosition.y,
+            ["EyeHeightAsPercent"] = Mathf.Clamp01((vrcViewPosition.y - 0.2f) / (5f - 0.2f)),
+        };
         var parameters = chilloutAnimatorController.parameters;
         for (var i = 0; i < parameters.Length; i++)
         {
-            if (nonZeroDefaultValueMap.TryGetValue(parameters[i].name, out var value))
+            if (defaults.TryGetValue(parameters[i].name, out var value))
             {
                 parameters[i] = new AnimatorControllerParameter
                 {

--- a/Tests/Editor/VRC3CVRGestureConversionTests.cs
+++ b/Tests/Editor/VRC3CVRGestureConversionTests.cs
@@ -478,6 +478,37 @@ public class VRC3CVRGestureConversionTests
         }
     }
 
+    // ---- the parameters ChilloutVR never moves, answered with a constant ----
+
+    [Test]
+    public void UnansweredParameters_HoldTheReadingThePlatformWouldNeverChange()
+    {
+        var controller = new AnimatorController { name = "defaultsTest" };
+        try
+        {
+            controller.AddParameter("EyeHeightAsMeters", AnimatorControllerParameterType.Float);
+            controller.AddParameter("EyeHeightAsPercent", AnimatorControllerParameterType.Float);
+            controller.AddParameter("AvatarVersion", AnimatorControllerParameterType.Int);
+            controller.AddParameter("ScaleFactor", AnimatorControllerParameterType.Float);
+            var core = new VRC3CVRCore();
+            typeof(VRC3CVRCore).GetField("chilloutAnimatorController", Flags).SetValue(core, controller);
+            typeof(VRC3CVRCore).GetField("vrcViewPosition", Flags).SetValue(core, new Vector3(0f, 1.6f, 0.1f));
+
+            typeof(VRC3CVRCore).GetMethod("SetNonZeroDefaultValueParameters", Flags).Invoke(core, null);
+
+            float DefaultFloat(string name) => controller.parameters.Single(p => p.name == name).defaultFloat;
+            Assert.AreEqual(1.6f, DefaultFloat("EyeHeightAsMeters"), 1e-4f, "the avatar's own view height, in metres");
+            // (1.6 - 0.2) / (5.0 - 0.2), the scaling limits VRChat states the percent against
+            Assert.AreEqual(0.2917f, DefaultFloat("EyeHeightAsPercent"), 1e-4f);
+            Assert.AreEqual(3, controller.parameters.Single(p => p.name == "AvatarVersion").defaultInt, "SDK3 is the only input the conversion has");
+            Assert.AreEqual(1f, DefaultFloat("ScaleFactor"), 1e-4f, "unscaled, which is the only state ChilloutVR has");
+        }
+        finally
+        {
+            Object.DestroyImmediate(controller);
+        }
+    }
+
     // ---- the hand layer names ChilloutVR mutes an emote with ----
 
     static string[] NameHandLayers(AnimatorController destination, params AnimatorControllerLayer[] layers)

--- a/Tests/Editor/VRC3CVRGestureConversionTests.cs
+++ b/Tests/Editor/VRC3CVRGestureConversionTests.cs
@@ -486,10 +486,18 @@ public class VRC3CVRGestureConversionTests
         var controller = new AnimatorController { name = "defaultsTest" };
         try
         {
-            controller.AddParameter("EyeHeightAsMeters", AnimatorControllerParameterType.Float);
-            controller.AddParameter("EyeHeightAsPercent", AnimatorControllerParameterType.Float);
-            controller.AddParameter("AvatarVersion", AnimatorControllerParameterType.Int);
-            controller.AddParameter("ScaleFactor", AnimatorControllerParameterType.Float);
+            // declared the way an author is free to declare them, since VRChat overwrites the
+            // declared value on the first frame and nothing here does
+            controller.parameters = new[]
+            {
+                new AnimatorControllerParameter { name = "EyeHeightAsMeters", type = AnimatorControllerParameterType.Float, defaultFloat = 99f },
+                new AnimatorControllerParameter { name = "EyeHeightAsPercent", type = AnimatorControllerParameterType.Float, defaultFloat = 99f },
+                new AnimatorControllerParameter { name = "AvatarVersion", type = AnimatorControllerParameterType.Int, defaultInt = 99 },
+                new AnimatorControllerParameter { name = "ScaleFactor", type = AnimatorControllerParameterType.Float, defaultFloat = 99f },
+                new AnimatorControllerParameter { name = "Earmuffs", type = AnimatorControllerParameterType.Bool, defaultBool = true },
+                new AnimatorControllerParameter { name = "ScaleModified", type = AnimatorControllerParameterType.Bool, defaultBool = true },
+                new AnimatorControllerParameter { name = "AngularY", type = AnimatorControllerParameterType.Float, defaultFloat = 99f },
+            };
             var core = new VRC3CVRCore();
             typeof(VRC3CVRCore).GetField("chilloutAnimatorController", Flags).SetValue(core, controller);
             typeof(VRC3CVRCore).GetField("vrcViewPosition", Flags).SetValue(core, new Vector3(0f, 1.6f, 0.1f));
@@ -502,6 +510,10 @@ public class VRC3CVRGestureConversionTests
             Assert.AreEqual(0.2917f, DefaultFloat("EyeHeightAsPercent"), 1e-4f);
             Assert.AreEqual(3, controller.parameters.Single(p => p.name == "AvatarVersion").defaultInt, "SDK3 is the only input the conversion has");
             Assert.AreEqual(1f, DefaultFloat("ScaleFactor"), 1e-4f, "unscaled, which is the only state ChilloutVR has");
+            bool DefaultBool(string name) => controller.parameters.Single(p => p.name == name).defaultBool;
+            Assert.IsFalse(DefaultBool("Earmuffs"), "a feature the platform does not have is never on");
+            Assert.IsFalse(DefaultBool("ScaleModified"));
+            Assert.AreEqual(0f, DefaultFloat("AngularY"), 1e-4f, "nobody is turning the player the conversion cannot measure");
         }
         finally
         {


### PR DESCRIPTION
#53 のうち `AngularY` の実装以外。いずれも実行時の供給は不要で、パラメータの既定値に書き込むだけで済む。

## なぜ「既定値のまま」ではだめか

VRChat ではクライアントが最初のフレームで宣言値を上書きするので、作者が宣言に何を入れていても意味を持たない。ChilloutVR では上書きする者がいないため、**宣言値がそのセッションの間ずっと読まれ続ける**。したがって 0 / false が正解の場合も、変換が明示的に書き込む必要がある。

## 書き込む値

| パラメータ | 値 | 変更 |
|---|---|---|
| `AvatarVersion` | `3` | **新規**。「SDK3 以降でビルドされていれば 3」で、変換の入力は常に SDK3 |
| `EyeHeightAsMeters` | `VRCAvatarDescriptor.ViewPosition.y` | **新規**。アバターごとに違うが変換時に確定する |
| `EyeHeightAsPercent` | `(視点高 - 0.2) / (5.0 - 0.2)` を 0〜1 でクランプ | **修正**。1 固定だったが、VRChat はスケール制限 0.2〜5.0m に対する割合として報告する。1.6m のアバターなら約 0.29 |
| `Earmuffs` | `false` | **新規**。ChilloutVR に無い機能なので、決して on にならない |
| `ScaleModified` | `false` | **新規**。同上（スケーリング機能が無い） |
| `AngularY` | `0` | **新規**。ChilloutVR の値から導出しておらず、供給もしていない。誰にも回されていないプレイヤーの値を読ませる |
| `ScaleFactor` / `ScaleFactorInverse` | `1` | 変更なし（コメントで理由を明記） |

スケール系が定数でよいのは、VRChat 側がランタイムのアバタースケーリング機能の値であり、ChilloutVR にその機能が無いため。CVR にユーザー操作のスケーリングが入った場合は `Type.AvatarHeight`(400) からの導出に切り替える（#53 に条件を記載）。`AngularY` を実際に供給する案も #53 に残してある。

マップ名は `nonZeroDefaultValueMap` → `platformAnswerDefaultValueMap` に変えた。ゼロを書き込むエントリが入ったため。

## テスト

`VRC3CVRGestureConversionTests` 27 件パス（新規 1 件。**作者が 99 や true を宣言していても上書きされる**ことを含めて検証）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
