### PR TITLE
stop calling the locomotion conversion not recommended

### DIFF
--- a/Editor/VRC3CVRConvertConfigDrawer.cs
+++ b/Editor/VRC3CVRConvertConfigDrawer.cs
@@ -9,14 +9,14 @@ public class VRC3CVRConvertConfigDrawer : PropertyDrawer
     class T
     {
         public static istring PlayableLayers => new istring("Playable Layers", "Playable Layers");
-        public static istring ConvertLocomotionAnimator => new istring("Convert Locomotion Animator (NOT RECOMMEND)", "Locomotionレイヤーを変換 (非推奨)");
-        public static istring ConvertLocomotionAnimatorDescription => new istring("Locomotion state machines will very likely not convert over correctly and this option is better left unticked for now", "Locomotionステートマシンは正しく変換されない可能性が高く、このオプションは今のところチェックを外しておくことをお勧めします");
+        public static istring ConvertLocomotionAnimator => new istring("Convert Locomotion Animator (movement)", "Locomotionレイヤーを変換 (移動)");
+        public static istring ConvertLocomotionAnimatorDescription => new istring("Replaces ChilloutVR's own locomotion layer with the avatar's Base layer. A Base layer holding only VRChat's proxy placeholders is left to ChilloutVR's locomotion.", "ChilloutVR自身のlocomotionレイヤーをアバターのBaseレイヤーで置き換えます。VRChatのプレースホルダーしか持たないBaseレイヤーはChilloutVRのlocomotionに任せます。");
         public static istring PlayLandingAnimation => new istring("Play the landing animation", "着地アニメーションを再生する");
         public static istring PlayLandingAnimationDescription => new istring("Without this the converted landing freezes to a single pose and the body dips sharply; this plays ChilloutVR's landing animation on its own timing instead.", "OFFだと変換後の着地がポーズ1枚固定になり体が急に沈むため、代わりにChilloutVRの着地アニメーションを本来のタイミングで再生します。");
         public static istring ConvertLocomotionTrackingControl => new istring("Convert Tracking Control in the locomotion layer", "locomotionレイヤーのTracking Controlを変換する");
         public static istring ConvertLocomotionTrackingControlDescription => new istring("Applies to every machine folded into the locomotion layer. Tracking Control, common in VRChat's landing states, causes full-body tracking jitter in ChilloutVR when converted.", "locomotionレイヤーに畳み込まれる機械すべてが対象です。VRChatの着地ステートにありがちなTracking Controlを変換するとCVRでFBTががたつく原因になります。");
         public static istring ConvertAdditiveAnimator => new istring("Convert Additive Animator (additive blend layers)", "Additiveレイヤーを変換");
-        public static istring ConvertAdditiveAnimatorDescription => new istring("Additive state machine is commonly used for additively blended animations on the base avatar. May cause bicycle pose on certain avatars.", "Additiveステートマシンは、ベースアバターの加算ブレンドアニメーションに一般的に使用されます。特定のアバターで自転車ポーズを引き起こす可能性があります。");
+        public static istring ConvertAdditiveAnimatorDescription => new istring("Additive state machine is commonly used for additively blended animations on the base avatar.", "Additiveステートマシンは、ベースアバターの加算ブレンドアニメーションに一般的に使用されます。");
         public static istring ConvertGestureAnimator => new istring("Convert Gesture Animator (hands)", "Gestureレイヤーを変換 (手)");
         public static istring ConvertGestureAnimatorDescription => new istring("If your avatar overwrites the default finger animations when performing expressions", "アバターが表情を実行するときにデフォルトの指のアニメーションを上書きする場合はON");
         public static istring ConvertActionAnimator => new istring("Convert Action Animator (emotes)", "Actionレイヤーを変換 (エモート)");

--- a/README.ja.md
+++ b/README.ja.md
@@ -4,7 +4,6 @@ VRChat SDK3のアバターをChilloutVR用に変換します。
 
 - 元のプロジェクトのバックアップを必ず取ってください。
 - 本プロジェクトは、元のプロジェクト（ https://github.com/imagitama/vrc3cvr ）をフォークしたプロジェクト（ https://github.com/SaracenOne/vrc3cvr ）をさらにフォークしたものです。
-- Locomotionレイヤーの変換は非推奨です。FXとGestureレイヤーのみの変換を推奨します。
 
 ## 動作確認済み環境
 
@@ -14,7 +13,7 @@ VRChat SDK3のアバターをChilloutVR用に変換します。
 
 ## 変換で行われること
 
-全体的にPhysBone固有の機能とFX/Gestureレイヤー以外が必要な機能を除けば多くの部分がそのまま動作します。
+全体的にPhysBone固有の機能を除けば多くの部分がそのまま動作します。
 
 - ChilloutVR用アバターコンポーネントの追加（存在しない場合）
 - 顔メッシュの設定
@@ -28,6 +27,9 @@ VRChat SDK3のアバターをChilloutVR用に変換します。
 - 各Animator Controller（Gesture、FXなど）をCVR用に変換  
   - `GestureLeftWeight` / `GestureRightWeight` の参照を変換（選択可能な2方式: 遅延なしの`GestureLeft`/`GestureRight`への書き換え、または全用途を再現するweightパラメータ生成（1フレーム遅延））
   - VRCParameterDriverなども変換
+- ChilloutVR自身のlocomotionレイヤーをアバターのBaseレイヤーで置き換え
+- Actionレイヤーをそのレイヤーに畳み込み、ChilloutVR自身のエモートメニューでエモートを再生
+- 独自の着席アニメーションを持つアバターでは、Sittingレイヤーも同様に畳み込み
 - VRC Contact SenderとReceiverをCVR PointerとCVR Advanced Avatar Triggerに変換
   - VRCContactと違って、CVR PointerやTriggerはContactが衝突した時にしか値を変更しません。この差異によって互換性の問題を生じる可能性があります。
   - プレイ中のContactのShape Typeの変更は非対応です。

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ Convert a VRChat SDK3 avatar to ChilloutVR with this Unity script.
 
 - Keep a BACKUP of your original project.
 - This is a fork of the forked project (https://github.com/SaracenOne/vrc3cvr) that is a fork of the original project (https://github.com/imagitama/vrc3cvr).
-- It is not recommended you convert avatars with custom locomotion controllers, only FX and Gesture controllers.
 
 Tested with:
 
@@ -16,7 +15,7 @@ Tested with:
 
 ## What does it do?
 
-Most things work as-is, except for PhysBone-specific features and features that require layers other than FX/Gesture.
+Most things work as-is, except for PhysBone-specific features.
 
 - adds a ChilloutVR avatar component (if missing)
 - sets the face mesh
@@ -30,6 +29,9 @@ Most things work as-is, except for PhysBone-specific features and features that 
 - converts each animator controller (gestures, FX, etc.) to support ChilloutVR's gesture system
   - references to `GestureLeftWeight`/`GestureRightWeight` are converted (two selectable modes: rewrite onto `GestureLeft`/`GestureRight` with no latency, or generate a weight parameter that reproduces every usage with one frame of latency)
   - converts VRCParameterDriver etc.
+- replaces ChilloutVR's own locomotion layer with the avatar's Base layer
+- folds the Action layer into that layer, so emotes play from ChilloutVR's own emote menu
+- folds the Sitting layer in the same way for an avatar with its own seated animation
 - Convert VRC Contact Senders and Receivers to CVR Pointer and CVR Advanced Avatar Trigger
   - Unlike VRC Contact, CVR Pointer and Trigger only change values when the contact collides. This difference may cause compatibility issues.
   - Changing Shape Type in game is not supported.


### PR DESCRIPTION
Locomotion のオプションには `(NOT RECOMMEND)` / `(非推奨)` が付き、説明は「正しく変換されない可能性が高いのでチェックを外しておくことを勧める」と書かれたままでした。Base レイヤーを素朴にマージしていた頃の記述です。

現状:

- Base レイヤーは CVR の locomotion レイヤーの**置き換え**として実装されている（`vrcBaseReplacesCckLocomotion`）
- 立たない場合は自分で降りる。`HasAuthoredMotion` / `HasLocomotionHub` を満たさなければ変換せず、警告を出して CVR 側の locomotion を残す
- Additive の「自転車ポーズを引き起こす可能性」も、Additive playable が加算合成されるようになった時点で原因が消えている

あわせて README（英/日）の「Locomotion の変換は非推奨、FX と Gesture のみ推奨」と「FX/Gesture 以外のレイヤーが必要な機能を除けば」を落とし、「変換で行われること」に locomotion 置き換え・エモート・着席の3行を足しました。

既定値は変えていません（別 PR）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)