### PR TITLE
convert every playable layer by default

### DIFF
--- a/Runtime/VRC3CVRConvertConfig.cs
+++ b/Runtime/VRC3CVRConvertConfig.cs
@@ -30,17 +30,17 @@ public class VRC3CVRConvertConfig
     public bool autoBake = true;
     public bool saveAssets = true;
 
-    public bool convertLocomotionLayer = false;
+    public bool convertLocomotionLayer = true;
     // Only takes effect when the Base layer replaces the CVR locomotion layer, which
     // convertLocomotionLayer gates.
     public bool playLandingAnimation = true;
     // Covers every machine that ends up in the layer owning CVR's locomotion: the Base layer that
     // takes it over and the machines folded into it.
     public bool convertLocomotionTrackingControl = false;
-    public bool convertAdditiveLayer = false;
+    public bool convertAdditiveLayer = true;
     public bool convertGestureLayer = true;
-    public bool convertActionLayer = false;
-    public bool convertSittingLayer = false;
+    public bool convertActionLayer = true;
+    public bool convertSittingLayer = true;
     public bool convertFXLayer = true;
     public bool preserveParameterSyncState = true;
     public bool convertVRCAnimatorLocomotionControl = true;


### PR DESCRIPTION
`convertLocomotionLayer` / `convertAdditiveLayer` / `convertActionLayer` / `convertSittingLayer` の既定値を `true` にします。

4つとも「CVR 側が既にやっていることを肩代わりできるか」を自分で判定し、できなければ CVR のレイヤーをそのまま残すようになったので、ユーザーが手で opt-in する理由が無くなりました。

- Locomotion: `HasAuthoredMotion` / `HasLocomotionHub` を満たさなければ置き換えない
- Action: `HasAuthoredMotion`（proxy_* だけなら CVR のエモートマシンを残す）。`convertLocomotionLayer` とは独立に動く
- Sitting: 独自の着席アニメーションが無ければ CVR の着席ポーズに任せる
- Additive: 加算合成として変換されるようになり、自転車ポーズの原因が解消済み

既に `VRC3CVR Avatar` コンポーネントが付いているアバターはシリアライズ済みの値を保つので、影響は新規に設定を作る場合のみです。

未検証: Unity の EditMode テスト。設定を明示していないテスト（メニュー変換・robustness・E2E）は既定値の変更で変換対象レイヤーが増えるため、マージ前に Test Runner を通したいです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)